### PR TITLE
POL-568 Load endpoints configuration

### DIFF
--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -150,4 +150,9 @@ public class ConfigSourceTest {
         assertEquals("n-api.svc:8000", ccs.getValue("clowder.endpoints.api"));
         assertEquals("n-gw.svc:8000", ccs.getValue("clowder.endpoints.gw"));
     }
+
+    @Test
+    void testUnknownClowderEndpoint() {
+        assertThrows(IllegalStateException.class, () -> ccs.getValue("clowder.endpoints.unknown"));
+    }
 }

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -145,4 +145,9 @@ public class ConfigSourceTest {
         assertThrows(IllegalStateException.class, () -> source.getValue("quarkus.datasource.username"));
     }
 
+    @Test
+    void testClowderEndpoints() {
+        assertEquals("n-api.svc:8000", ccs.getValue("clowder.endpoints.api"));
+        assertEquals("n-gw.svc:8000", ccs.getValue("clowder.endpoints.gw"));
+    }
 }


### PR DESCRIPTION
The `endpoints` section of the Clowder configuration is needed to allow policies-ui-backend to contact policies-engine.