### PR TITLE
POL-568 Log the reason why the Clowder endpoints could not be loaded

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -207,18 +207,23 @@ public class ClowderConfigSource implements ConfigSource {
             }
 
             if (configKey.startsWith(CLOWDER_ENDPOINTS)) {
-                JsonArray endpoints = root.getJsonArray("endpoints");
-                if (endpoints == null) {
-                    throw new IllegalStateException("No endpoints section found");
-                }
-                String endpointName = configKey.substring(CLOWDER_ENDPOINTS.length());
-                for (int i = 0; i < endpoints.size(); i++) {
-                    JsonObject endpoint = endpoints.getJsonObject(i);
-                    if (endpoint.getString("name").equals(endpointName)) {
-                        return endpoint.getString("hostname") + ":" + endpoint.getJsonNumber("port").intValue();
+                try {
+                    JsonArray endpoints = root.getJsonArray("endpoints");
+                    if (endpoints == null) {
+                        throw new IllegalStateException("No endpoints section found");
                     }
+                    String endpointName = configKey.substring(CLOWDER_ENDPOINTS.length());
+                    for (int i = 0; i < endpoints.size(); i++) {
+                        JsonObject endpoint = endpoints.getJsonObject(i);
+                        if (endpoint.getString("name").equals(endpointName)) {
+                            return endpoint.getString("hostname") + ":" + endpoint.getJsonNumber("port").intValue();
+                        }
+                    }
+                    throw new IllegalStateException("Endpoint with name '" + endpointName + "' not found in the endpoints section");
+                } catch (IllegalStateException e) {
+                    log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
+                    throw e;
                 }
-                throw new IllegalStateException("Endpoint with name '" + endpointName + "' not found in the endpoints section");
             }
         }
 


### PR DESCRIPTION
When a Clowder endpoint configuration is not found, the following message is currently logged by Quarkus without any details about the reason of the failure:
```
Failed to load config value of type class java.lang.String for: clowder.endpoints.policies-engine
```

This PR adds the following log entry:
```
2021-10-07 17:28:49,049 ERROR [com.red.clo.com.clo.con.ClowderConfigSource] (Quarkus Main Thread) Failed to load config key 'clowder.endpoints.policies-engine' from the Clowder configuration: Endpoint with name 'policies-engine' not found in the endpoints section
```