### PR TITLE
Load Clowder endpoints using the app field

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -212,14 +212,15 @@ public class ClowderConfigSource implements ConfigSource {
                     if (endpoints == null) {
                         throw new IllegalStateException("No endpoints section found");
                     }
-                    String endpointName = configKey.substring(CLOWDER_ENDPOINTS.length());
+                    String requestedEndpoint = configKey.substring(CLOWDER_ENDPOINTS.length());
                     for (int i = 0; i < endpoints.size(); i++) {
                         JsonObject endpoint = endpoints.getJsonObject(i);
-                        if (endpoint.getString("name").equals(endpointName)) {
+                        String currentEndpoint = endpoint.getString("app") + "." + endpoint.getString("name");
+                        if (currentEndpoint.equals(requestedEndpoint)) {
                             return endpoint.getString("hostname") + ":" + endpoint.getJsonNumber("port").intValue();
                         }
                     }
-                    throw new IllegalStateException("Endpoint with name '" + endpointName + "' not found in the endpoints section");
+                    throw new IllegalStateException("Endpoint '" + requestedEndpoint + "' not found in the endpoints section");
                 } catch (IllegalStateException e) {
                     log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
                     throw e;

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -147,8 +147,8 @@ public class ConfigSourceTest {
 
     @Test
     void testClowderEndpoints() {
-        assertEquals("n-api.svc:8000", ccs.getValue("clowder.endpoints.api"));
-        assertEquals("n-gw.svc:8000", ccs.getValue("clowder.endpoints.gw"));
+        assertEquals("n-api.svc:8000", ccs.getValue("clowder.endpoints.notifications.api"));
+        assertEquals("n-gw.svc:8000", ccs.getValue("clowder.endpoints.notifications.gw"));
     }
 
     @Test


### PR DESCRIPTION
Clowder endpoints are now retrieved from their `app` and `name` instead of the `name` alone before.