### PR TITLE
Align endpoint app and name separator with Clowder

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -215,7 +215,7 @@ public class ClowderConfigSource implements ConfigSource {
                     String requestedEndpoint = configKey.substring(CLOWDER_ENDPOINTS.length());
                     for (int i = 0; i < endpoints.size(); i++) {
                         JsonObject endpoint = endpoints.getJsonObject(i);
-                        String currentEndpoint = endpoint.getString("app") + "." + endpoint.getString("name");
+                        String currentEndpoint = endpoint.getString("app") + "-" + endpoint.getString("name");
                         if (currentEndpoint.equals(requestedEndpoint)) {
                             return endpoint.getString("hostname") + ":" + endpoint.getJsonNumber("port").intValue();
                         }

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -147,8 +147,8 @@ public class ConfigSourceTest {
 
     @Test
     void testClowderEndpoints() {
-        assertEquals("n-api.svc:8000", ccs.getValue("clowder.endpoints.notifications.api"));
-        assertEquals("n-gw.svc:8000", ccs.getValue("clowder.endpoints.notifications.gw"));
+        assertEquals("n-api.svc:8000", ccs.getValue("clowder.endpoints.notifications-api"));
+        assertEquals("n-gw.svc:8000", ccs.getValue("clowder.endpoints.notifications-gw"));
     }
 
     @Test


### PR DESCRIPTION
When they are concatenated, the endpoints `app` and `name` fields are separated with a dash in the Clowder config:
```
"endpoints":[{"app":"policies-ui-backend","hostname":"policies-ui-backend-policies-ui-backend.ephemeral-21.svc","name":"policies-ui-backend","port":8000},{"app":"rbac","hostname":"rbac-service.ephemeral-21.svc","name":"service","port":8000},{"app":"ingress","hostname":"ingress-service.ephemeral-21.svc","name":"service","port":8000},{"app":"policies-engine","hostname":"policies-engine-policies-engine.ephemeral-21.svc","name":"policies-engine","port":8000},{"app":"host-inventory","hostname":"host-inventory-service.ephemeral-21.svc","name":"service","port":8000}]
```