### PR TITLE
NOTIF-336 Fix Postgres URL params separator

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -176,7 +176,7 @@ public class ClowderConfigSource implements ConfigSource {
                         jdbcUrl = jdbcUrl + "?sslmode=" + sslMode;
                     }
                     if (verifyFull) {
-                        jdbcUrl = jdbcUrl + " sslrootcert=" + createTempCertFile(dbObject);
+                        jdbcUrl = jdbcUrl + "&sslrootcert=" + createTempCertFile(dbObject);
                     }
                     return jdbcUrl;
                 }
@@ -186,7 +186,7 @@ public class ClowderConfigSource implements ConfigSource {
                         hostPortDb = hostPortDb + "?sslmode=" + sslMode;
                     }
                     if (verifyFull) {
-                        hostPortDb = hostPortDb + " sslrootcert=" + createTempCertFile(dbObject);
+                        hostPortDb = hostPortDb + "&sslrootcert=" + createTempCertFile(dbObject);
                     }
 
                     return hostPortDb;

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class ConfigSourceTest {
 
-    private static final Pattern VERIFY_FULL_URL_PATTERN = Pattern.compile("(jdbc:(tracing:)?)?postgresql://some.host:15432/some-db\\?sslmode=verify-full sslrootcert=(.+rds-ca-root.+\\.crt)");
+    private static final Pattern VERIFY_FULL_URL_PATTERN = Pattern.compile("(jdbc:(tracing:)?)?postgresql://some.host:15432/some-db\\?sslmode=verify-full&sslrootcert=(.+rds-ca-root.+\\.crt)");
     private static final String EXPECTED_CERT = "Dummy value";
 
     static Properties appProps;


### PR DESCRIPTION
The following exception was thrown on stage with Clowder:
```
__  ____  __  _____   ___  __ ____  ______ 
 --/ __ \/ / / / _ | / _ \/ //_/ / / / __/ 
 -/ /_/ / /_/ / __ |/ , _/ ,< / /_/ /\ \   
--\___\_\____/_/ |_/_/|_/_/|_|\____/___/   
2021-11-10 16:33:37,562 INFO  [com.red.clo.com.clo.con.ClowderConfigSourceFactory] (main) Using ClowderConfigSource with config at /cdapp/cdappconfig.json
2021-11-10 16:33:38,368 INFO  [LoggingCloudWatch] (main) Initializing Quarkus Logging Cloudwatch Extension
2021-11-10 16:33:38,372 INFO  [LoggingCloudWatch] (main) Logging to log-group: notifications-stage and log-stream: notifications-backend-notifications-backend-b8778f5f5-n99ch
2021-11-10 16:33:41,775 ERROR [io.qua.run.Application] (main) Failed to start application (with profile prod): java.lang.IllegalArgumentException: Could not find an appropriate SSL mode for the value [verify-full sslrootcert=/tmp/rds-ca-root8463188710495691461.crt].
	at io.vertx.pgclient.SslMode.of(SslMode.java:75)
	at io.vertx.pgclient.impl.PgConnectionUriParser.parseParameters(PgConnectionUriParser.java:177)
	at io.vertx.pgclient.impl.PgConnectionUriParser.doParse(PgConnectionUriParser.java:85)
	at io.vertx.pgclient.impl.PgConnectionUriParser.parse(PgConnectionUriParser.java:59)
	at io.vertx.pgclient.PgConnectOptions.fromUri(PgConnectOptions.java:65)
	at io.quarkus.reactive.pg.client.runtime.PgPoolRecorder.toPgConnectOptions(PgPoolRecorder.java:101)
	at io.quarkus.reactive.pg.client.runtime.PgPoolRecorder.initialize(PgPoolRecorder.java:63)
	at io.quarkus.reactive.pg.client.runtime.PgPoolRecorder.configurePgPool(PgPoolRecorder.java:45)
	at io.quarkus.deployment.steps.ReactivePgClientProcessor$build-682528754.deploy_0(ReactivePgClientProcessor$build-682528754.zig:123)
	at io.quarkus.deployment.steps.ReactivePgClientProcessor$build-682528754.deploy(ReactivePgClientProcessor$build-682528754.zig:40)
	at io.quarkus.runner.ApplicationImpl.doStart(ApplicationImpl.zig:875)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:105)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:66)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:42)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:119)
	at io.quarkus.runner.GeneratedMain.main(GeneratedMain.zig:29)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:48)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:25)
```
The correct params separator with `io.vertx.pgclient` is `&`: [PgConnectionUriParser](https://github.com/eclipse-vertx/vertx-sql-client/blob/c26b1c143657bd96c412cc5cfc07c2765d482273/vertx-pg-client/src/main/java/io/vertx/pgclient/impl/PgConnectionUriParser.java#L147).