### PR TITLE
POL-621 Don't throw an exception when a requested endpoint is missing

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -250,7 +250,8 @@ public class ClowderConfigSource implements ConfigSource {
                             return "http://" + endpoint.hostname + ":" + endpoint.port;
                         }
                     }
-                    throw new IllegalStateException("Endpoint '" + requestedEndpoint + "' not found in the endpoints section");
+                    log.warn("Endpoint '" + requestedEndpoint + "' not found in the endpoints section");
+                    return null;
                 } catch (IllegalStateException e) {
                     log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
                     throw e;

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -164,7 +164,7 @@ public class ConfigSourceTest {
 
     @Test
     void testUnknownClowderEndpoint() {
-        assertThrows(IllegalStateException.class, () -> ccs.getValue("clowder.endpoints.unknown"));
+        assertNull(ccs.getValue("clowder.endpoints.unknown"));
     }
 
     @Test


### PR DESCRIPTION
Depending on the environment, a Clowder `optionalDependency` may or may not be available. We must therefore allow missing endpoints in the Clowder configuration.

This happens for example on `fedramp-stage` with `policies-ui-backend` which depends optionally on `notifications-backend`.