### PR TITLE
POL-621 Fix kafka.ssl.truststore.location value

### DIFF
--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -210,12 +210,14 @@ public class ConfigSourceTest {
     }
 
     @Test
-    void testKafkaSaslAuthtype() {
+    void testKafkaSaslAuthtype() throws IOException {
         ClowderConfigSource ccs2 = new ClowderConfigSource("target/test-classes/cdappconfig_kafka_sasl_authtype.json", APP_PROPS_MAP);
         assertEquals("org.apache.kafka.common.security.scram.ScramLoginModule required username=\"john\" password=\"doe\";", ccs2.getValue("kafka.sasl.jaas.config"));
         assertEquals(KAFKA_SASL_MECHANISM, ccs2.getValue("kafka.sasl.mechanism"));
         assertEquals(KAFKA_SASL_SECURITY_PROTOCOL, ccs2.getValue("kafka.security.protocol"));
-        assertEquals("/tmp/dummy/path", ccs2.getValue("kafka.ssl.truststore.location"));
+        String truststoreLocation = ccs2.getValue("kafka.ssl.truststore.location");
+        String cert = Files.readString(Path.of(truststoreLocation), UTF_8);
+        assertEquals(EXPECTED_CERT, cert);
     }
 
     @Test

--- a/src/test/resources/cdappconfig_kafka_sasl_authtype.json
+++ b/src/test/resources/cdappconfig_kafka_sasl_authtype.json
@@ -28,7 +28,7 @@
       {
         "hostname": "ephemeral-host.svc",
         "port": 29092,
-        "cacert": "/tmp/dummy/path",
+        "cacert": "Dummy value",
         "authtype": "sasl",
         "sasl": {
           "username": "john",


### PR DESCRIPTION
The cert data was returned as the `kafka.ssl.truststore.location` value while a temp cert file needs to be created and its location must be returned.

This is very similar to the RDS cert file management.