### PR TITLE
EVNT-523 treat none type logging as disabled cloudwatch

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -241,19 +241,26 @@ public class ClowderConfigSource implements ConfigSource {
                 if (root.logging.cloudwatch == null) {
                     throw new IllegalStateException("No cloudwatch section found in logging object");
                 }
-                int prefixLen = QUARKUS_LOG_CLOUDWATCH.length();
-                String sub = configKey.substring(prefixLen+1);
-                switch (sub) {
-                    case "access-key-id":
-                        return root.logging.cloudwatch.accessKeyId;
-                    case "access-key-secret":
-                        return root.logging.cloudwatch.secretAccessKey;
-                    case "region":
-                        return root.logging.cloudwatch.region;
-                    case "log-group":
-                        return root.logging.cloudwatch.logGroup;
-                    default:
-                        // fall through to fetching the value from application.properties
+                if (root.logging.type != null && root.logging.type.equals("cloudwatch")) {
+                    int prefixLen = QUARKUS_LOG_CLOUDWATCH.length();
+                    String sub = configKey.substring(prefixLen+1);
+                    switch (sub) {
+                        case "access-key-id":
+                            return root.logging.cloudwatch.accessKeyId;
+                        case "access-key-secret":
+                            return root.logging.cloudwatch.secretAccessKey;
+                        case "region":
+                            return root.logging.cloudwatch.region;
+                        case "log-group":
+                            return root.logging.cloudwatch.logGroup;
+                        default:
+                            // fall through to fetching the value from application.properties
+                    }
+                } else {
+                    // treat other types of logging (like none) as disabled CloudWatch logging
+                    if (configKey.equals(QUARKUS_LOG_CLOUDWATCH + ".enabled")) {
+                        return "false";
+                    }
                 }
             }
 

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -145,6 +145,13 @@ public class ConfigSourceTest {
     }
 
     @Test
+    void testLogNone() {
+        ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig2.json", APP_PROPS_MAP);
+        String value = source.getValue("quarkus.log.cloudwatch.enabled");
+        assertEquals("false", value);
+    }
+
+    @Test
     void testNoKafkaSection() {
         ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig3.json", APP_PROPS_MAP);
         assertThrows(IllegalStateException.class, () -> source.getValue("kafka.bootstrap.servers"));

--- a/src/test/resources/cdappconfig.json
+++ b/src/test/resources/cdappconfig.json
@@ -48,7 +48,7 @@
       "region": "eu-central-1",
       "secretAccessKey": "very-secret"
     },
-    "type": "null"
+    "type": "cloudwatch"
   },
   "metricsPath": "/metrics",
   "metricsPort": 9000,

--- a/src/test/resources/cdappconfig2.json
+++ b/src/test/resources/cdappconfig2.json
@@ -52,7 +52,7 @@
       "region": "",
       "secretAccessKey": ""
     },
-    "type": "null"
+    "type": "none"
   },
   "metricsPath": "/metrics",
   "metricsPort": 9000,


### PR DESCRIPTION
This is to allow environments w/o CloudWatch to coexist by trusting the Clowder config.
It observes logging type, and enables cloudwatch only for `cloudwatch` type.

References:
* https://github.com/RedHatInsights/clowder/blob/master/docs/antora/modules/providers/pages/logging.adoc