### PR TITLE
fix(logging): only look for type null

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -241,7 +241,14 @@ public class ClowderConfigSource implements ConfigSource {
                 if (root.logging.cloudwatch == null) {
                     throw new IllegalStateException("No cloudwatch section found in logging object");
                 }
-                if (root.logging.type != null && root.logging.type.equals("cloudwatch")) {
+
+                // Check for not null type and not "null" provider to enable and read
+                // cloudwatch properties from Clowder config.
+                // Note that the "null" type is a Clowder logging provider that disables
+                // central logging.
+                // Empty string type has to be treated as cloudwatch, as one of the Clowder
+                // logging providers (appinterface) did not set it correctly.
+                if (root.logging.type != null && !root.logging.type.equals("null")) {
                     int prefixLen = QUARKUS_LOG_CLOUDWATCH.length();
                     String sub = configKey.substring(prefixLen+1);
                     switch (sub) {
@@ -257,7 +264,7 @@ public class ClowderConfigSource implements ConfigSource {
                             // fall through to fetching the value from application.properties
                     }
                 } else {
-                    // treat other types of logging (like none) as disabled CloudWatch logging
+                    // treat null logging type as disabled CloudWatch logging
                     if (configKey.equals(QUARKUS_LOG_CLOUDWATCH + ".enabled")) {
                         return "false";
                     }

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -145,7 +145,28 @@ public class ConfigSourceTest {
     }
 
     @Test
-    void testLogNone() {
+    void testLogOnEmptyLoggingType() {
+        // Tests for a Clowder buggy case where the type is not set
+        // for appinterface provider, that in fact sets cloudwatch credentials.
+        ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig4.json", APP_PROPS_MAP);
+        String value = source.getValue("quarkus.log.cloudwatch.access-key-id");
+        assertEquals("my-key-id", value);
+        value = source.getValue("quarkus.log.cloudwatch.access-key-secret");
+        assertEquals("very-secret", value);
+        value = source.getValue("quarkus.log.cloudwatch.region");
+        assertEquals("eu-central-1", value);
+        value = source.getValue("quarkus.log.cloudwatch.log-group");
+        assertEquals("my-log-group", value);
+        value = source.getValue("quarkus.log.cloudwatch.log-stream-name");
+        assertEquals("my-log-stream", value);
+        value = source.getValue("quarkus.log.cloudwatch.level");
+        assertEquals("INFO", value);
+        value = source.getValue("quarkus.log.cloudwatch.enabled"); // Does not exist.
+        assertNull(value);
+    }
+
+    @Test
+    void testLogNullProvider() {
         ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig2.json", APP_PROPS_MAP);
         String value = source.getValue("quarkus.log.cloudwatch.enabled");
         assertEquals("false", value);

--- a/src/test/resources/cdappconfig2.json
+++ b/src/test/resources/cdappconfig2.json
@@ -52,7 +52,7 @@
       "region": "",
       "secretAccessKey": ""
     },
-    "type": "none"
+    "type": "null"
   },
   "metricsPath": "/metrics",
   "metricsPort": 9000,

--- a/src/test/resources/cdappconfig4.json
+++ b/src/test/resources/cdappconfig4.json
@@ -1,0 +1,26 @@
+{
+  "database": {
+    "adminPassword": "s3cr3t",
+    "adminUsername": "postgres",
+    "hostname": "some.host",
+    "name": "some-db",
+    "password": "secret",
+    "port": 15432,
+    "sslMode": "require",
+    "username": "aUser"
+  },
+  "logging": {
+    "cloudwatch": {
+      "accessKeyId": "my-key-id",
+      "logGroup": "my-log-group",
+      "region": "eu-central-1",
+      "secretAccessKey": "very-secret"
+    },
+    "type": ""
+  },
+  "metricsPath": "/metrics",
+  "metricsPort": 9000,
+  "privatePort": 10000,
+  "publicPort": 8000,
+  "webPort": 8000
+}


### PR DESCRIPTION
Only turn off cloudwatch if the type is "null" or not defined.

This should fix logging with [appinferface Clowder logging provider](https://github.com/RedHatInsights/clowder/blob/master/controllers/cloud.redhat.com/providers/logging/appinterface.go) which sets this to empty string.

The `null` logging type is set at https://github.com/RedHatInsights/clowder/blob/16e66a2c37556feb9d7f8f26a9909169be4d00d0/controllers/cloud.redhat.com/providers/logging/none.go#L29