### PR TITLE
fix(kafka): kafka.ssl.truststore.location on missing cacert

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -346,7 +346,7 @@ public class ClowderConfigSource implements ConfigSource {
         if (certData != null) {
             return createTempCertFile("kafka-cacert", certData);
         } else {
-            return null;
+            return "";
         }
     }
 


### PR DESCRIPTION
Fixes issue when the `cacert` is not provided, which leads to:
```
Modification time of key store could not be obtained: "": java.nio.file.NoSuchFileException: ""
```

ENVT-668