### PR TITLE
RHCLOUD-26703 | feature: support for private endpoints

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfig.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfig.java
@@ -9,6 +9,7 @@ public class ClowderConfig {
 
     public DatabaseConfig database;
     public List<EndpointConfig> endpoints;
+    public List<PrivateEndpointConfig> privateEndpoints;
     public KafkaConfig kafka;
     public LoggingConfig logging;
     public String metricsPath;

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -331,75 +331,8 @@ public class ClowderConfigSource implements ConfigSource {
                     if (root.endpoints == null) {
                         throw new IllegalStateException("No endpoints section found");
                     }
-                    String requestedEndpointConfig = configKey.substring(CLOWDER_ENDPOINTS.length());
-                    String[] configPath = requestedEndpointConfig.split("\\.");
 
-                    String requestedEndpoint;
-                    String param;
-                    final String FORMAT_EXAMPLE = "[endpoint-name].[url|trust-store-path|trust-store-password|trust-store-type]";
-                    if (configPath.length == 1) {
-                        log.warn("Endpoint '" + requestedEndpointConfig + "' is using the old format. Please move to the new one: " + FORMAT_EXAMPLE);
-                        requestedEndpoint = configPath[0];
-                        param = CLOWDER_ENDPOINTS_PARAM_URL;
-                    } else if (configPath.length != 2) {
-                        throw new IllegalArgumentException("Endpoint '" + requestedEndpointConfig + "' expects a different format: " + FORMAT_EXAMPLE);
-                    } else {
-                        requestedEndpoint = configPath[0];
-                        param = configPath[1];
-                    }
-
-                    EndpointConfig endpoint = null;
-
-                    for (EndpointConfig endpointCandidate : root.endpoints) {
-                        String currentEndpoint = endpointCandidate.app + "-" + endpointCandidate.name;
-                        if (currentEndpoint.equals(requestedEndpoint)) {
-                            endpoint = endpointCandidate;
-                            break;
-                        }
-                    }
-
-                    if (endpoint == null) {
-                        log.warn("Endpoint '" + requestedEndpoint + "' not found in the endpoints section");
-                        return null;
-                    }
-
-                    switch (param) {
-                        case CLOWDER_ENDPOINTS_PARAM_URL:
-                            if (usesTls(endpoint)) {
-                                return "https://" + endpoint.hostname + ":" + endpoint.tlsPort;
-                            } else {
-                                return "http://" + endpoint.hostname + ":" + endpoint.port;
-                            }
-                        case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH:
-                            if (usesTls(endpoint)) {
-                                ensureTlsCertPathIsPresent();
-
-                                createTruststoreFile(root.tlsCAPath);
-                                return trustStorePath;
-                            }
-
-                            return null;
-                        case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PASSWORD:
-                            if (usesTls(endpoint)) {
-                                ensureTlsCertPathIsPresent();
-
-                                createTruststoreFile(root.tlsCAPath);
-                                return trustStorePassword;
-                            }
-
-                            return null;
-                        case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_TYPE:
-                            if (usesTls(endpoint)) {
-                                ensureTlsCertPathIsPresent();
-
-                                return CLOWDER_ENDPOINT_STORE_TYPE;
-                            }
-
-                            return null;
-                        default:
-                            log.warn("Endpoint '" + requestedEndpoint + "' requested an unknown param: '" + param + "'");
-                            return null;
-                    }
+                    return this.processEndpoints(this.root.endpoints, configKey, CLOWDER_ENDPOINTS, "Endpoint");
                 } catch (IllegalStateException e) {
                     log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
                     throw e;
@@ -411,75 +344,8 @@ public class ClowderConfigSource implements ConfigSource {
                     if (root.privateEndpoints == null) {
                         throw new IllegalStateException("No private endpoints section found");
                     }
-                    final String requestedEndpointConfig = configKey.substring(CLOWDER_PRIVATE_ENDPOINTS.length());
-                    final String[] configPath = requestedEndpointConfig.split("\\.");
 
-                    final String requestedPrivateEndpoint;
-                    final String param;
-                    final String FORMAT_EXAMPLE = "[private-endpoint-name].[url|trust-store-path|trust-store-password|trust-store-type]";
-                    if (configPath.length == 1) {
-                        log.warnf("Private endpoint '%s' is using the old format. Please move to the new one: %s", requestedEndpointConfig, FORMAT_EXAMPLE);
-                        requestedPrivateEndpoint = configPath[0];
-                        param = CLOWDER_ENDPOINTS_PARAM_URL;
-                    } else if (configPath.length != 2) {
-                        throw new IllegalArgumentException(String.format("Private endpoint '%s' expects a different format: %s" +requestedEndpointConfig, FORMAT_EXAMPLE));
-                    } else {
-                        requestedPrivateEndpoint = configPath[0];
-                        param = configPath[1];
-                    }
-
-                    PrivateEndpointConfig privateEndpoint = null;
-
-                    for (final PrivateEndpointConfig privateEndpointCandidate : root.privateEndpoints) {
-                        final String currentEndpoint = String.format("%s-%s", privateEndpointCandidate.app, privateEndpointCandidate.name);
-                        if (currentEndpoint.equals(requestedPrivateEndpoint)) {
-                            privateEndpoint = privateEndpointCandidate;
-                            break;
-                        }
-                    }
-
-                    if (privateEndpoint == null) {
-                        log.warnf("Private endpoint '%s' not found in the private endpoints section", requestedPrivateEndpoint);
-                        return null;
-                    }
-
-                    switch (param) {
-                        case CLOWDER_ENDPOINTS_PARAM_URL:
-                            if (usesTls(privateEndpoint)) {
-                                return String.format("https://%s:%s", privateEndpoint.hostname, privateEndpoint.tlsPort);
-                            } else {
-                                return String.format("http://%s:%s", privateEndpoint.hostname, privateEndpoint.port);
-                            }
-                        case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH:
-                            if (usesTls(privateEndpoint)) {
-                                ensureTlsCertPathIsPresent();
-
-                                createTruststoreFile(root.tlsCAPath);
-                                return trustStorePath;
-                            }
-
-                            return null;
-                        case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PASSWORD:
-                            if (usesTls(privateEndpoint)) {
-                                ensureTlsCertPathIsPresent();
-
-                                createTruststoreFile(root.tlsCAPath);
-                                return trustStorePassword;
-                            }
-
-                            return null;
-                        case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_TYPE:
-                            if (usesTls(privateEndpoint)) {
-                                ensureTlsCertPathIsPresent();
-
-                                return CLOWDER_ENDPOINT_STORE_TYPE;
-                            }
-
-                            return null;
-                        default:
-                            log.warnf("Private endpoint '%s' requested an unknown param: '%s'", requestedPrivateEndpoint, param);
-                            return null;
-                    }
+                    return this.processEndpoints(this.root.privateEndpoints, configKey, CLOWDER_PRIVATE_ENDPOINTS, "Private endpoint");
                 } catch (IllegalStateException e) {
                     log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
                     throw e;
@@ -492,6 +358,96 @@ public class ClowderConfigSource implements ConfigSource {
         }
         else {
             return null;
+        }
+    }
+
+    /**
+     * Attempts to find the corresponding value for the provided configuration
+     * key. If the URL parameter has been requested, then depending on whether
+     * the endpoint has a TLS port or not, a full URL including the protocol
+     * is returned. For the rest of parameters it returns the corresponding
+     * value.
+     * @param endpointConfigs the list of configurations to be looked for the
+     *                        corresponding value.
+     * @param configKey       the configuration key specified in the
+     *                        "application.properties" file.
+     * @param clowderKey      the Clowder key which represents the path to
+     *                        either the regular endpoints or the private
+     *                        endpoints.
+     * @param endpointType    the type of the endpoint which the function will
+     *                        process. Used mainly for error and log messages.
+     * @return a full URL including the protocol in the case of requesting an
+     * endpoint's URL parameter. Regular values for the rest of the parameters.
+     */
+    private String processEndpoints(final List<? extends EndpointConfig> endpointConfigs, final String configKey, final String clowderKey, final String endpointType) {
+        final String requestedEndpointConfig = configKey.substring(clowderKey.length());
+        final String[] configPath = requestedEndpointConfig.split("\\.");
+
+        final String requestedEndpoint;
+        final String param;
+        final String FORMAT_EXAMPLE = String.format("[%s].[url|trust-store-path|trust-store-password|trust-store-type]", endpointType);
+        if (configPath.length == 1) {
+            log.warnf("%s '%s' is using the old format. Please move to the new one: %s", endpointType, requestedEndpointConfig, FORMAT_EXAMPLE);
+            requestedEndpoint = configPath[0];
+            param = CLOWDER_ENDPOINTS_PARAM_URL;
+        } else if (configPath.length != 2) {
+            throw new IllegalArgumentException(String.format("%s '%s' expects a different format: %s", endpointType, requestedEndpointConfig, FORMAT_EXAMPLE));
+        } else {
+            requestedEndpoint = configPath[0];
+            param = configPath[1];
+        }
+
+        EndpointConfig endpointConfig = null;
+
+        for (final EndpointConfig configCandidate : endpointConfigs) {
+            final String currentEndpoint = String.format("%s-%s", configCandidate.app, configCandidate.name);
+            if (currentEndpoint.equals(requestedEndpoint)) {
+                endpointConfig = configCandidate;
+                break;
+            }
+        }
+
+        if (endpointConfig == null) {
+            log.warnf("%s '%s' not found in the %1s section", endpointType, requestedEndpoint);
+            return null;
+        }
+
+        switch (param) {
+            case CLOWDER_ENDPOINTS_PARAM_URL:
+                if (usesTls(endpointConfig)) {
+                    return String.format("https://%s:%s", endpointConfig.hostname, endpointConfig.tlsPort);
+                } else {
+                    return String.format("http://%s:%s", endpointConfig.hostname, endpointConfig.port);
+                }
+            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH:
+                if (usesTls(endpointConfig)) {
+                    ensureTlsCertPathIsPresent();
+
+                    createTruststoreFile(this.root.tlsCAPath);
+                    return this.trustStorePath;
+                }
+
+                return null;
+            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PASSWORD:
+                if (usesTls(endpointConfig)) {
+                    ensureTlsCertPathIsPresent();
+
+                    createTruststoreFile(this.root.tlsCAPath);
+                    return this.trustStorePassword;
+                }
+
+                return null;
+            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_TYPE:
+                if (usesTls(endpointConfig)) {
+                    ensureTlsCertPathIsPresent();
+
+                    return CLOWDER_ENDPOINT_STORE_TYPE;
+                }
+
+                return null;
+            default:
+                log.warnf("%s '%s' requested an unknown param: '%s'", endpointType, requestedEndpoint, param);
+                return null;
         }
     }
 
@@ -509,10 +465,6 @@ public class ClowderConfigSource implements ConfigSource {
 
     private boolean usesTls(EndpointConfig endpointConfig) {
         return endpointConfig.tlsPort != null && !endpointConfig.tlsPort.equals(PORT_NOT_SET);
-    }
-
-    private boolean usesTls(final PrivateEndpointConfig privateEndpointConfig) {
-        return privateEndpointConfig.tlsPort != null && !privateEndpointConfig.tlsPort.equals(PORT_NOT_SET);
     }
 
     private void ensureTlsCertPathIsPresent() {

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -59,7 +59,7 @@ public class ClowderConfigSource implements ConfigSource {
     private static final String QUARKUS_LOG_CLOUDWATCH = "quarkus.log.cloudwatch";
     private static final String QUARKUS_DATASOURCE_JDBC_URL = "quarkus.datasource.jdbc.url";
     private static final String CLOWDER_ENDPOINTS = "clowder.endpoints.";
-    private static final String CLOWDER_PRIVATE_ENDPOINTS = "clowder.private.endpoints.";
+    private static final String CLOWDER_PRIVATE_ENDPOINTS = "clowder.private-endpoints.";
     private static final String CLOWDER_ENDPOINTS_PARAM_URL = "url";
     private static final String CLOWDER_ENDPOINT_STORE_TYPE = "PKCS12";
     private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH = "trust-store-path";

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/PrivateEndpointConfig.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/PrivateEndpointConfig.java
@@ -1,0 +1,13 @@
+package com.redhat.cloud.common.clowder.configsource;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PrivateEndpointConfig {
+
+    public String app;
+    public String hostname;
+    public String name;
+    public Integer port;
+    public Integer tlsPort;
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/PrivateEndpointConfig.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/PrivateEndpointConfig.java
@@ -3,11 +3,4 @@ package com.redhat.cloud.common.clowder.configsource;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PrivateEndpointConfig {
-
-    public String app;
-    public String hostname;
-    public String name;
-    public Integer port;
-    public Integer tlsPort;
-}
+public class PrivateEndpointConfig extends EndpointConfig { }

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -388,4 +388,67 @@ public class ConfigSourceTest {
         assertEquals("MIIFgTCCA2mgAwIBAgIJAPWS//Ai2FLxMA0GCSqGSIb3DQEBCwUAMFcxCzAJBgNVBAYTAlhYMRAwDgYDVQQIDAd1bmtub3duMRAwDgYDVQQHDAd1bmtub3duMRAwDgYDVQQKDAd1bmtub3duMRIwEAYDVQQDDAlsb2NhbGhvc3QwHhcNMjMwMzA2MTcyNDU2WhcNMjMwNDA1MTcyNDU2WjBXMQswCQYDVQQGEwJYWDEQMA4GA1UECAwHdW5rbm93bjEQMA4GA1UEBwwHdW5rbm93bjEQMA4GA1UECgwHdW5rbm93bjESMBAGA1UEAwwJbG9jYWxob3N0MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEArEaE0E9XdzER7eqbOwsHad2zHygF06YfO87wrbJmae+CplZJWDzo/9KwhbvmhUuJ5Q5WNG5gOzuogw+xUGZ4Hr2uyD0JMhBVyipo+sh+Y3zdAHnogzKBS/OouKbLC3bBeVuzh51vKbaTB8jWqyRPVkgFlDng6B+1cdwCeTr8pRvfNb4EVUFMTSbspnn+mMzPaZqvBwl/T/kGUgg9rmZjGWfRpNEs5/IU+of/r+ak8UZbU2G+luml6rpyzEBwVTNx35JwvBQgWuPfZm/k1LsF9OXiQU+E+Cz4DPzVAGIgPvzu2FYr+onYq09aQ75WtH6/LlRDTVexy4VQrJA6Xwd/l6pYToHgOjlTXR8lbgkGgMvWWVgXCUNz5E+6GDgKxK5snfWSufF57zR1HrxbdW76irXPMVYaXxQ/gj8dts1xZnyE5/2AYvJT4sMEalGEqgt3SDMjRqBsKr0frsHZ0o1oJMjChc37HFiYPNaAaZdTZ37bOQp0So0ex0NVdFaWjSJfgIpNXzPxYIoHNuJHlvduAMPnK1dh13A8U2gC9szNwLi7TYq82MqhRYbf/qcv10sZNo2iUsCBlO9zB6Y9lpiY2Qmht7lJ2o4f2Ke1TdBm1y6o5MQQWbBo5nP2j37PZJS5qz8LJaIzSaCuX5fs7ifnHaho9uxjVtKocf7qI7qBCXcCAwEAAaNQME4wHQYDVR0OBBYEFMEvvXfdRUBi0GmJVALBk3Onn0W8MB8GA1UdIwQYMBaAFMEvvXfdRUBi0GmJVALBk3Onn0W8MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIBAAev6v4un8KSPpwbDE1W6CR9wiUR6RNo+dlgtdQFQKufe/d3A8TbZRiKQZVy/ez1Zi00qHAY7wnGZQejwfVJYgwtKX/kE1wNnbO3t6LP7Iz3JeBo8/pa8Ajf+n6YX5YlJ5IbUVsX4pkyITHvjOUuPm940He8jr4aVqf7HT9K0drgRAX657V4ci+psEvZSBjUFItUrv2xpfK0yykMSrUFulKF5gfJvCVoWBcqMLazaTPMnBWCwgndi9mvE+N345l05aK+5Jxu6piewEcPiKyu1OAGWvlqV9/fj8KmrWSJXM26JwKmUxlewtB3TzLfOGWHeFYSrEdWva/jxO8ZgxZJoM68AQQbUqZyXGHwLzZ0nlF/94051WJK+YZ+4d1397LvYeOpcxb0qiA/xxGhBspV8llgUmdPW090C4LeU14nZK88p3gSFVW/NZ1Mrxl2XnnL2EjerkWRmFAxPe66QSPUGFGfsSvUeGB8BsKAxs3bovQBqw/UJ8aWfJNEQOSjKR0qkwl5hs910dluzxRQW7IrH676LimyGMbADbI0JxzT4JdT2nFyJnSFXXKPhybr6fs85fgb/dYZrn0cl/KcAddEiBNT9f5KHRFQDr31tu10TU3RGa1TR8r9aoelUFhK3d0ECspPw9iGmjOFup7cIsSJYk+0Aefwnxi9ca0OXKUCVxYs", certs.get(1));
         assertEquals("MIIFgTCCA2mgAwIBAgIJAIGzkhzYA2UMMA0GCSqGSIb3DQEBCwUAMFcxCzAJBgNVBAYTAlhYMRAwDgYDVQQIDAd1bmtub3duMRAwDgYDVQQHDAd1bmtub3duMRAwDgYDVQQKDAd1bmtub3duMRIwEAYDVQQDDAlsb2NhbGhvc3QwHhcNMjMwMzA2MTcwNTIwWhcNMjMwNDA1MTcwNTIwWjBXMQswCQYDVQQGEwJYWDEQMA4GA1UECAwHdW5rbm93bjEQMA4GA1UEBwwHdW5rbm93bjEQMA4GA1UECgwHdW5rbm93bjESMBAGA1UEAwwJbG9jYWxob3N0MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAymTDYToVyWUvV0ioRFbp9uZ8WOiC88D1Nx4JX0VR29q1orvtF2+P+/4/sAwlYPojS4VhmVsQPbS7bZVZ022N7jno3p7ZYTyd08nnW3QP51W7oJmzypjuOnG/kHvMtgzlQi5Irz8ka7n9regLqiIHvtdGG+ft1O1snutyxvpi2BAuW/F3QUwjIECXoKzmuQtVIRuemt+pFHQp8NB3q80SpHLelG11bBNOAESCDDszN5tnzIcDxOxO3QuhclHKwfiRF6R2vGTVGLrGbmWrRU08A1VP/rA9cU+bfb8jPBDvxBmPwSGWpr/6IikLtpYyuFF8AzHOTELAgnGNP3FLQNVZ+s4Gx4nHMxeEg9X+xFx3x217lTizZ8JOn+kFoT8bmsQoMj0ZDc/grR5RH6R1mho4wjog6SmvuCJpqARyioWyyLdcj8xKAdBQZ6ZVOWf5jQ0Z09kS5KVXFLxS1cL/kbMkGev1ityX+w+zQcgHFO1PswC10VCkpVo1ypurVpWjvEJYwpdm3UhawK76OLTBeHyuejSNlH/u1gybHLsPImUgI4svUqZTZqBgcKwIXzpAbhsa7da+IOVlIPUlGbDpMmrprw/9+uNu9Lrq7mszoJjDzgoSGY6HJW3QmDX9/KBP9p8GhbkZA5cMKfj1dAdQrvK1C72yEdi13FR/FqKtamixPHcCAwEAAaNQME4wHQYDVR0OBBYEFCNk8S9w77ADF8oukI/4QkuelbQ1MB8GA1UdIwQYMBaAFCNk8S9w77ADF8oukI/4QkuelbQ1MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIBABh/jJlqLCyUOJ4fypmihWcWLooQINBeeuvhoiEFYxI16f+0jVmJI0FwEjRyz8FM2jxvXJnr3ErhzLBNI+jqTyzU2Dr/gD2ZyU3RFv8X+l9x3cSXNUHYk/y53V6/6GyQU06OQcoHi+ksawppdhpfn/G8ep8aB/yF2krL/JRuq8igXvKuwCUjgAFKQk27UcKDiGLfmvtivBpLqjniqF8C27RnaDVIOw/sZB8G1xVzBzRGawdm5VNKLQv2GrIoxySSAtEdjyCKEkUWkmDlpmQQM6ZWAGx/+G6y7KWMLCWXCn6rWtPl10ucUjm+cVycox4a3bB5OCTo0ws5jK4AUYxrq2VI0ISxnc3RUhXLlctOV7eD2jlmKctp6dTFYenQqwQ2nBYOu0wwTbd57MrFz3L1xr83bagjk2zjEakg4bdOK/KZdSfW1cTznSF9/SKr3LXvV6ux1oD8qtfwFOKCyba2qYycnghQ9Ev50yyXt3mM/IhbfQ7EAfir/m702wyqpc4lR1RjDB4Y+P7z/RRLUSMpAd0Lc3zsh+KQYLrMlQsRKPFzzJqSnmf7slyDqRTrDrtKWASldaZmllqDGwmbG+ygEtdt0SXRol9kg0X+QtykCtuMGSrpKt0qu9wV0Fc7mnJDRtW65OjHGUSDrYFUorRwl3ijzgPe4zaH9I1P6xJ1qL8D", certs.get(2));
     }
+
+    /**
+     * Tests that both regular and private endpoints are correctly read.
+     */
+    @Test
+    void endpointsAndPrivateEndpoints() {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig5.json", APP_PROPS_MAP);
+
+        // Read the regular endpoints.
+        assertEquals("http://notifications-api.svc:9876", source.getValue("clowder.endpoints.notifications-api.url"));
+        assertEquals("http://notifications-gateway.svc:1234", source.getValue("clowder.endpoints.notifications-gateway.url"));
+
+        // Read the private endpoints.
+        assertEquals("http://notifications-engine.svc:5555", source.getValue("clowder.private.endpoints.notifications-engine.url"));
+    }
+
+    /**
+     * Tests that the URL value contains the "https" prefix and that the key
+     * store with the single certificate gets created.
+     */
+    @Test
+    void testSecuredPrivateEndpoint() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
+
+        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.private.endpoints.notifications-api.url"));
+
+        final String path = cc.getValue("clowder.private.endpoints.notifications-api.trust-store-path");
+        final String password = cc.getValue("clowder.private.endpoints.notifications-api.trust-store-password");
+        final String type = cc.getValue("clowder.private.endpoints.notifications-api.trust-store-type");
+
+        assertNotNull(path);
+        assertNotNull(password);
+        assertNotNull(type);
+
+        final KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(new FileInputStream(path), password.toCharArray());
+
+        assertEquals(1, Collections.list(keyStore.aliases()).size());
+    }
+
+    /**
+     * Tests that the URL value contains the "https" prefix and that the key
+     * store with multiple certificates gets created.
+     */
+    @Test
+    void testSecuredPrivateEndpointMultipleCert() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint_multiple_cert.json", APP_PROPS_MAP);
+
+        assertEquals("https://notifications-api.svc:9876", source.getValue("clowder.private.endpoints.notifications-api.url"));
+
+        final String path = source.getValue("clowder.private.endpoints.notifications-api.trust-store-path");
+        final String password = source.getValue("clowder.private.endpoints.notifications-api.trust-store-password");
+        final String type = source.getValue("clowder.private.endpoints.notifications-api.trust-store-type");
+
+        assertNotNull(path);
+        assertNotNull(password);
+        assertNotNull(type);
+
+        final KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(new FileInputStream(path), password.toCharArray());
+
+        assertEquals(3, Collections.list(keyStore.aliases()).size());
+    }
 }

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -401,7 +401,7 @@ public class ConfigSourceTest {
         assertEquals("http://notifications-gateway.svc:1234", source.getValue("clowder.endpoints.notifications-gateway.url"));
 
         // Read the private endpoints.
-        assertEquals("http://notifications-engine.svc:5555", source.getValue("clowder.private.endpoints.notifications-engine.url"));
+        assertEquals("http://notifications-engine.svc:5555", source.getValue("clowder.private-endpoints.notifications-engine.url"));
     }
 
     /**
@@ -412,11 +412,11 @@ public class ConfigSourceTest {
     void testSecuredPrivateEndpoint() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
         ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
 
-        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.private.endpoints.notifications-api.url"));
+        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.private-endpoints.notifications-api.url"));
 
-        final String path = cc.getValue("clowder.private.endpoints.notifications-api.trust-store-path");
-        final String password = cc.getValue("clowder.private.endpoints.notifications-api.trust-store-password");
-        final String type = cc.getValue("clowder.private.endpoints.notifications-api.trust-store-type");
+        final String path = cc.getValue("clowder.private-endpoints.notifications-api.trust-store-path");
+        final String password = cc.getValue("clowder.private-endpoints.notifications-api.trust-store-password");
+        final String type = cc.getValue("clowder.private-endpoints.notifications-api.trust-store-type");
 
         assertNotNull(path);
         assertNotNull(password);
@@ -436,11 +436,11 @@ public class ConfigSourceTest {
     void testSecuredPrivateEndpointMultipleCert() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
         final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint_multiple_cert.json", APP_PROPS_MAP);
 
-        assertEquals("https://notifications-api.svc:9876", source.getValue("clowder.private.endpoints.notifications-api.url"));
+        assertEquals("https://notifications-api.svc:9876", source.getValue("clowder.private-endpoints.notifications-api.url"));
 
-        final String path = source.getValue("clowder.private.endpoints.notifications-api.trust-store-path");
-        final String password = source.getValue("clowder.private.endpoints.notifications-api.trust-store-password");
-        final String type = source.getValue("clowder.private.endpoints.notifications-api.trust-store-type");
+        final String path = source.getValue("clowder.private-endpoints.notifications-api.trust-store-path");
+        final String password = source.getValue("clowder.private-endpoints.notifications-api.trust-store-password");
+        final String type = source.getValue("clowder.private-endpoints.notifications-api.trust-store-type");
 
         assertNotNull(path);
         assertNotNull(password);

--- a/src/test/resources/cdappconfig5.json
+++ b/src/test/resources/cdappconfig5.json
@@ -1,0 +1,24 @@
+{
+  "endpoints": [
+    {
+      "app": "notifications",
+      "hostname": "notifications-api.svc",
+      "name": "api",
+      "port": 9876
+    },
+    {
+      "app": "notifications",
+      "hostname": "notifications-gateway.svc",
+      "name": "gateway",
+      "port": 1234
+    }
+  ],
+  "privateEndpoints": [
+    {
+      "app": "notifications",
+      "hostname": "notifications-engine.svc",
+      "name": "engine",
+      "port": 5555
+    }
+  ]
+}

--- a/src/test/resources/cdappconfig_secured_private_endpoint.json
+++ b/src/test/resources/cdappconfig_secured_private_endpoint.json
@@ -1,0 +1,68 @@
+{
+  "database": {
+    "adminPassword": "s3cr3t",
+    "adminUsername": "postgres",
+    "hostname": "some.host",
+    "name": "some-db",
+    "password": "secret",
+    "port": 15432,
+    "sslMode": "require",
+    "username": "aUser"
+  },
+  "privateEndpoints": [
+    {
+      "app": "notifications",
+      "hostname": "notifications-api.svc",
+      "name": "api",
+      "tlsPort": 9876
+    }
+  ],
+  "kafka": {
+    "brokers": [
+      {
+        "hostname": "ephemeral-host.svc",
+        "port": 29092
+      }
+    ],
+    "topics": [
+      {
+        "name": "platform-tmp-12345",
+        "requestedName": "platform.notifications.ingress"
+      },
+      {
+        "name": "platform-tmp-666",
+        "requestedName": "platform.notifications.alerts"
+      }
+    ]
+  },
+  "logging": {
+    "cloudwatch": {
+      "accessKeyId": "my-key-id",
+      "logGroup": "my-log-group",
+      "region": "eu-central-1",
+      "secretAccessKey": "very-secret"
+    },
+    "type": "cloudwatch"
+  },
+  "metricsPath": "/metrics",
+  "metricsPort": 9000,
+  "objectStore": {
+    "accessKey": "secret",
+    "buckets": [
+      {
+        "accessKey": "more-secret",
+        "name": "returned-name",
+        "requestedName": "a-bucket",
+        "secretKey": "really-secret"
+      }
+    ],
+    "hostname": "minio12345.svc",
+    "port": 9000,
+    "secretKey": "another-secret",
+    "tls": false
+  },
+  "privatePort": 10000,
+  "publicPort": 8000,
+  "webPort": 8000,
+  "tlsCAPath": "target/test-classes/cert01.pem"
+}

--- a/src/test/resources/cdappconfig_secured_private_endpoint_multiple_cert.json
+++ b/src/test/resources/cdappconfig_secured_private_endpoint_multiple_cert.json
@@ -1,0 +1,68 @@
+{
+  "database": {
+    "adminPassword": "s3cr3t",
+    "adminUsername": "postgres",
+    "hostname": "some.host",
+    "name": "some-db",
+    "password": "secret",
+    "port": 15432,
+    "sslMode": "require",
+    "username": "aUser"
+  },
+  "privateEndpoints": [
+    {
+      "app": "notifications",
+      "hostname": "notifications-api.svc",
+      "name": "api",
+      "tlsPort": 9876
+    }
+  ],
+  "kafka": {
+    "brokers": [
+      {
+        "hostname": "ephemeral-host.svc",
+        "port": 29092
+      }
+    ],
+    "topics": [
+      {
+        "name": "platform-tmp-12345",
+        "requestedName": "platform.notifications.ingress"
+      },
+      {
+        "name": "platform-tmp-666",
+        "requestedName": "platform.notifications.alerts"
+      }
+    ]
+  },
+  "logging": {
+    "cloudwatch": {
+      "accessKeyId": "my-key-id",
+      "logGroup": "my-log-group",
+      "region": "eu-central-1",
+      "secretAccessKey": "very-secret"
+    },
+    "type": "cloudwatch"
+  },
+  "metricsPath": "/metrics",
+  "metricsPort": 9000,
+  "objectStore": {
+    "accessKey": "secret",
+    "buckets": [
+      {
+        "accessKey": "more-secret",
+        "name": "returned-name",
+        "requestedName": "a-bucket",
+        "secretKey": "really-secret"
+      }
+    ],
+    "hostname": "minio12345.svc",
+    "port": 9000,
+    "secretKey": "another-secret",
+    "tls": false
+  },
+  "privatePort": 10000,
+  "publicPort": 8000,
+  "webPort": 8000,
+  "tlsCAPath": "target/test-classes/cert02.pem"
+}


### PR DESCRIPTION
Adds support for parsing the "private endpoints" section of the configuration file.

## Links

[[RHCLOUD-26703]](https://issues.redhat.com/browse/RHCLOUD-26703)

## CC

- @gburges 
- @josejulio 