### PR TITLE
RHCLOUD-27017 | feature: skip optional private endpoints without failing

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -343,7 +343,7 @@ public class ClowderConfigSource implements ConfigSource {
             if (configKey.startsWith(CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS)) {
                 try {
                     if (root.privateEndpoints == null) {
-                        log.errorf("No private endpoints section found. Returning empty string for the \"%s\" configuration key", configKey);
+                        log.infof("No private endpoints section found. Returning empty string for the \"%s\" configuration key", configKey);
                         return "";
                     }
 

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -60,6 +60,7 @@ public class ClowderConfigSource implements ConfigSource {
     private static final String QUARKUS_DATASOURCE_JDBC_URL = "quarkus.datasource.jdbc.url";
     private static final String CLOWDER_ENDPOINTS = "clowder.endpoints.";
     private static final String CLOWDER_PRIVATE_ENDPOINTS = "clowder.private-endpoints.";
+    private static final String CLOWDER_OPTIONAL_ENDPOINTS = "clowder.optional-endpoints.";
     private static final String CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS = "clowder.optional-private-endpoints.";
     private static final String CLOWDER_ENDPOINTS_PARAM_URL = "url";
     private static final String CLOWDER_ENDPOINT_STORE_TYPE = "PKCS12";
@@ -335,6 +336,20 @@ public class ClowderConfigSource implements ConfigSource {
 
                     return this.processEndpoints(this.root.endpoints, configKey, CLOWDER_ENDPOINTS, "Endpoint");
                 } catch (IllegalStateException e) {
+                    log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
+                    throw e;
+                }
+            }
+
+            if (configKey.startsWith(CLOWDER_OPTIONAL_ENDPOINTS)) {
+                try {
+                    if (root.endpoints == null) {
+                        log.infof("No endpoints section found. Returning empty string for the \"%s\" configuration key", configKey);
+                        return "";
+                    }
+
+                    return this.processEndpoints(this.root.endpoints, configKey, CLOWDER_OPTIONAL_ENDPOINTS, "Endpoint");
+                } catch (final IllegalStateException e) {
                     log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
                     throw e;
                 }

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -60,6 +60,7 @@ public class ClowderConfigSource implements ConfigSource {
     private static final String QUARKUS_DATASOURCE_JDBC_URL = "quarkus.datasource.jdbc.url";
     private static final String CLOWDER_ENDPOINTS = "clowder.endpoints.";
     private static final String CLOWDER_PRIVATE_ENDPOINTS = "clowder.private-endpoints.";
+    private static final String CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS = "clowder.optional-private-endpoints.";
     private static final String CLOWDER_ENDPOINTS_PARAM_URL = "url";
     private static final String CLOWDER_ENDPOINT_STORE_TYPE = "PKCS12";
     private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH = "trust-store-path";
@@ -333,6 +334,20 @@ public class ClowderConfigSource implements ConfigSource {
                     }
 
                     return this.processEndpoints(this.root.endpoints, configKey, CLOWDER_ENDPOINTS, "Endpoint");
+                } catch (IllegalStateException e) {
+                    log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
+                    throw e;
+                }
+            }
+
+            if (configKey.startsWith(CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS)) {
+                try {
+                    if (root.privateEndpoints == null) {
+                        log.errorf("No private endpoints section found. Returning empty string for the \"%s\" configuration key", configKey);
+                        return "";
+                    }
+
+                    return this.processEndpoints(this.root.privateEndpoints, configKey, CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS, "Private endpoint");
                 } catch (IllegalStateException e) {
                     log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
                     throw e;

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -484,7 +484,7 @@ public class ConfigSourceTest {
     void testSecuredOptionalPrivateEndpoint() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
         ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
 
-        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.private-endpoints.notifications-api.url"));
+        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.optional-private-endpoints.notifications-api.url"));
 
         final String path = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path");
         final String password = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password");

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -411,6 +411,15 @@ public class ConfigSourceTest {
     }
 
     /**
+     * Tests that when a configuration key for an optional endpoint doesn't
+     * exist, a null value is returned.
+     */
+    @Test
+    void testOptionalEndpointNotExistsConfigurationKey() {
+        assertNull(ccs.getValue("clowder.optional-endpoints.non-existent.url"));
+    }
+
+    /**
      * Tests that the URL value contains the "https" prefix and that the key
      * store with the single certificate gets created when an optional endpoint
      * is specified in the configuration key.
@@ -489,6 +498,18 @@ public class ConfigSourceTest {
         // Read the private endpoints.
         assertEquals("http://notifications-engine.svc:5555", source.getValue("clowder.private-endpoints.notifications-engine.url"));
     }
+
+    /**
+     * Tests that when a configuration key for an optional private endpoint
+     * doesn't exist, a null value is returned.
+     */
+    @Test
+    void testOptionalPrivateEndpointNotExistsConfigurationKey() {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig5.json", APP_PROPS_MAP);
+
+        assertNull(source.getValue("clowder.optional-private-endpoints.non-existent.url"));
+    }
+
 
     /**
      * Tests that the URL value contains the "https" prefix and that the key

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -390,6 +390,92 @@ public class ConfigSourceTest {
     }
 
     /**
+     * Tests that optional private endpoints are correctly read.
+     */
+    @Test
+    void testOptionalEndpoints() {
+        // Read the optional private endpoints.
+        assertEquals("http://n-api.svc:8000", ccs.getValue("clowder.optional-endpoints.notifications-api.url"));
+    }
+
+    /**
+     * Tests that when the "endpoints" configuration is missing for an optional
+     * configuration key, the empty string is returned.
+     */
+    @Test
+    void testOptionalEndpointEmptyString() {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_missing_endpoints.json", APP_PROPS_MAP);
+
+        // The returned value should be the empty string.
+        assertEquals("", source.getValue("clowder.optional-endpoints.notifications-inexistent.url"));
+    }
+
+    /**
+     * Tests that the URL value contains the "https" prefix and that the key
+     * store with the single certificate gets created when an optional endpoint
+     * is specified in the configuration key.
+     */
+    @Test
+    void testSecuredOptionalEndpoint() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_secured_endpoint.json", APP_PROPS_MAP);
+
+        assertEquals("https://n-api.svc:9999", source.getValue("clowder.optional-endpoints.notifications-api.url"));
+
+        final String path = source.getValue("clowder.optional-endpoints.notifications-api.trust-store-path");
+        final String password = source.getValue("clowder.optional-endpoints.notifications-api.trust-store-password");
+        final String type = source.getValue("clowder.optional-endpoints.notifications-api.trust-store-type");
+
+        assertNotNull(path);
+        assertNotNull(password);
+        assertNotNull(type);
+
+        final KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(new FileInputStream(path), password.toCharArray());
+
+        assertEquals(1, Collections.list(keyStore.aliases()).size());
+    }
+
+    /**
+     * Tests that the URL value contains the "https" prefix and that the key
+     * store with multiple certificates gets created when an optional endpoint
+     * is specified in the configuration key.
+     */
+    @Test
+    void testSecuredOptionalEndpointMultipleCert() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_secured_endpoint_multiple_cert.json", APP_PROPS_MAP);
+
+        assertEquals("https://n-api.svc:9999", source.getValue("clowder.optional-endpoints.notifications-api.url"));
+
+        final String path = source.getValue("clowder.optional-endpoints.notifications-api.trust-store-path");
+        final String password = source.getValue("clowder.optional-endpoints.notifications-api.trust-store-password");
+        final String type = source.getValue("clowder.optional-endpoints.notifications-api.trust-store-type");
+
+        assertNotNull(path);
+        assertNotNull(password);
+        assertNotNull(type);
+
+        final KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(new FileInputStream(path), password.toCharArray());
+
+        assertEquals(3, Collections.list(keyStore.aliases()).size());
+    }
+
+    /**
+     * Tests that the requested optional endpoints' parameters are empty
+     * strings.
+     */
+    @Test
+    void testSecuredOptionalEndpointEmptyString() {
+        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_missing_endpoints.json", APP_PROPS_MAP);
+
+        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.url"));
+
+        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.trust-store-path"));
+        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.trust-store-password"));
+        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.trust-store-type"));
+    }
+
+    /**
      * Tests that both regular and private endpoints are correctly read.
      */
     @Test

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -451,4 +451,92 @@ public class ConfigSourceTest {
 
         assertEquals(3, Collections.list(keyStore.aliases()).size());
     }
+
+    /**
+     * Tests that optional private endpoints are correctly read.
+     */
+    @Test
+    void testOptionalPrivateEndpoints() {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig5.json", APP_PROPS_MAP);
+
+        // Read the optional private endpoints.
+        assertEquals("http://notifications-engine.svc:5555", source.getValue("clowder.optional-private-endpoints.notifications-engine.url"));
+    }
+
+    /**
+     * Tests that when the "private endpoints" configuration is missing for
+     * an optional configuration key, the empty string is returned.
+     */
+    @Test
+    void testOptionalPrivateEndpointEmptyString() {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig.json", APP_PROPS_MAP);
+
+        // The returned value should be the empty string.
+        assertEquals("", source.getValue("clowder.optional-private-endpoints.notifications-engine.url"));
+    }
+
+    /**
+     * Tests that the URL value contains the "https" prefix and that the key
+     * store with the single certificate gets created when an optional private
+     * endpoint is specified in the configuration key.
+     */
+    @Test
+    void testSecuredOptionalPrivateEndpoint() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
+
+        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.private-endpoints.notifications-api.url"));
+
+        final String path = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path");
+        final String password = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password");
+        final String type = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-type");
+
+        assertNotNull(path);
+        assertNotNull(password);
+        assertNotNull(type);
+
+        final KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(new FileInputStream(path), password.toCharArray());
+
+        assertEquals(1, Collections.list(keyStore.aliases()).size());
+    }
+
+    /**
+     * Tests that the URL value contains the "https" prefix and that the key
+     * store with multiple certificates gets created when an optional private
+     * endpoint is specified in the configuration key.
+     */
+    @Test
+    void testSecuredOptionalPrivateEndpointMultipleCert() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint_multiple_cert.json", APP_PROPS_MAP);
+
+        assertEquals("https://notifications-api.svc:9876", source.getValue("clowder.optional-private-endpoints.notifications-api.url"));
+
+        final String path = source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path");
+        final String password = source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password");
+        final String type = source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-type");
+
+        assertNotNull(path);
+        assertNotNull(password);
+        assertNotNull(type);
+
+        final KeyStore keyStore = KeyStore.getInstance(type);
+        keyStore.load(new FileInputStream(path), password.toCharArray());
+
+        assertEquals(3, Collections.list(keyStore.aliases()).size());
+    }
+
+    /**
+     * Tests that the requested optional private endpoints' parameters are
+     * empty strings.
+     */
+    @Test
+    void testSecuredOptionalPrivateEndpointEmptyString() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
+        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig.json", APP_PROPS_MAP);
+
+        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.url"));
+
+        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path"));
+        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password"));
+        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-type"));
+    }
 }

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -407,7 +407,7 @@ public class ConfigSourceTest {
         final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_missing_endpoints.json", APP_PROPS_MAP);
 
         // The returned value should be the empty string.
-        assertEquals("", source.getValue("clowder.optional-endpoints.notifications-inexistent.url"));
+        assertEquals("", source.getValue("clowder.optional-endpoints.notifications-api.url"));
     }
 
     /**

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -466,13 +466,13 @@ public class ConfigSourceTest {
      */
     @Test
     void testSecuredOptionalEndpointEmptyString() {
-        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_missing_endpoints.json", APP_PROPS_MAP);
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_missing_endpoints.json", APP_PROPS_MAP);
 
-        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.url"));
+        assertEquals("", source.getValue("clowder.optional-endpoints.notifications-api.url"));
 
-        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.trust-store-path"));
-        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.trust-store-password"));
-        assertEquals("", cc.getValue("clowder.optional-endpoints.notifications-api.trust-store-type"));
+        assertEquals("", source.getValue("clowder.optional-endpoints.notifications-api.trust-store-path"));
+        assertEquals("", source.getValue("clowder.optional-endpoints.notifications-api.trust-store-password"));
+        assertEquals("", source.getValue("clowder.optional-endpoints.notifications-api.trust-store-type"));
     }
 
     /**
@@ -496,13 +496,13 @@ public class ConfigSourceTest {
      */
     @Test
     void testSecuredPrivateEndpoint() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
-        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
 
-        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.private-endpoints.notifications-api.url"));
+        assertEquals("https://notifications-api.svc:9876", source.getValue("clowder.private-endpoints.notifications-api.url"));
 
-        final String path = cc.getValue("clowder.private-endpoints.notifications-api.trust-store-path");
-        final String password = cc.getValue("clowder.private-endpoints.notifications-api.trust-store-password");
-        final String type = cc.getValue("clowder.private-endpoints.notifications-api.trust-store-type");
+        final String path = source.getValue("clowder.private-endpoints.notifications-api.trust-store-path");
+        final String password = source.getValue("clowder.private-endpoints.notifications-api.trust-store-password");
+        final String type = source.getValue("clowder.private-endpoints.notifications-api.trust-store-type");
 
         assertNotNull(path);
         assertNotNull(password);
@@ -568,13 +568,13 @@ public class ConfigSourceTest {
      */
     @Test
     void testSecuredOptionalPrivateEndpoint() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
-        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig_secured_private_endpoint.json", APP_PROPS_MAP);
 
-        assertEquals("https://notifications-api.svc:9876", cc.getValue("clowder.optional-private-endpoints.notifications-api.url"));
+        assertEquals("https://notifications-api.svc:9876", source.getValue("clowder.optional-private-endpoints.notifications-api.url"));
 
-        final String path = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path");
-        final String password = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password");
-        final String type = cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-type");
+        final String path = source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path");
+        final String password = source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password");
+        final String type = source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-type");
 
         assertNotNull(path);
         assertNotNull(password);
@@ -617,12 +617,12 @@ public class ConfigSourceTest {
      */
     @Test
     void testSecuredOptionalPrivateEndpointEmptyString() throws KeyStoreException, IOException, CertificateException, NoSuchAlgorithmException {
-        ClowderConfigSource cc = new ClowderConfigSource("target/test-classes/cdappconfig.json", APP_PROPS_MAP);
+        final ClowderConfigSource source = new ClowderConfigSource("target/test-classes/cdappconfig.json", APP_PROPS_MAP);
 
-        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.url"));
+        assertEquals("", source.getValue("clowder.optional-private-endpoints.notifications-api.url"));
 
-        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path"));
-        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password"));
-        assertEquals("", cc.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-type"));
+        assertEquals("", source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-path"));
+        assertEquals("", source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-password"));
+        assertEquals("", source.getValue("clowder.optional-private-endpoints.notifications-api.trust-store-type"));
     }
 }

--- a/src/test/resources/cdappconfig_missing_endpoints.json
+++ b/src/test/resources/cdappconfig_missing_endpoints.json
@@ -1,0 +1,59 @@
+{
+  "database": {
+    "adminPassword": "s3cr3t",
+    "adminUsername": "postgres",
+    "hostname": "some.host",
+    "name": "some-db",
+    "password": "secret",
+    "port": 15432,
+    "sslMode": "require",
+    "username": "aUser"
+  },
+  "kafka": {
+    "brokers": [
+      {
+        "hostname": "ephemeral-host.svc",
+        "port": 29092
+      }
+    ],
+    "topics": [
+      {
+        "name": "platform-tmp-12345",
+        "requestedName": "platform.notifications.ingress"
+      },
+      {
+        "name": "platform-tmp-666",
+        "requestedName": "platform.notifications.alerts"
+      }
+    ]
+  },
+  "logging": {
+    "cloudwatch": {
+      "accessKeyId": "my-key-id",
+      "logGroup": "my-log-group",
+      "region": "eu-central-1",
+      "secretAccessKey": "very-secret"
+    },
+    "type": "cloudwatch"
+  },
+  "metricsPath": "/metrics",
+  "metricsPort": 9000,
+  "objectStore": {
+    "accessKey": "secret",
+    "buckets": [
+      {
+        "accessKey": "more-secret",
+        "name": "returned-name",
+        "requestedName": "a-bucket",
+        "secretKey": "really-secret"
+      }
+    ],
+    "hostname": "minio12345.svc",
+    "port": 9000,
+    "secretKey": "another-secret",
+    "tls": false
+  },
+  "privatePort": 10000,
+  "publicPort": 8000,
+  "webPort": 8000
+}


### PR DESCRIPTION
This change is intended for optional dependencies that leave their configuration parameters in the "private endpoints" section. When applications depend on us, and they try to deploy everything to an environment, they might end up without transitive dependencies, if these are specified in the "optional dependencies" section of our ClowdApp. This can cause the configuration reader to fail because the configurations of those transitive dependencies will not be present, which in turn stops the engine from booting.

We recently had an issue where the provisioning team was trying to deploy their application, which depended on Notifications, in the ephemeral environment. Since the export service was defined as an optional dependency, it was not being deployed along with Notifications. This caused the configuration reader to fail, because of the missing configuration. Therefore, we need a way to allow skipping certain configuration values for these optional transitive dependencies.

## Links

[[RHCLOUD-27017]](https://issues.redhat.com/browse/RHCLOUD-27017)