### PR TITLE
Fix MissingFormatArgumentException for missing endpoints

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -438,7 +438,7 @@ public class ClowderConfigSource implements ConfigSource {
         }
 
         if (endpointConfig == null) {
-            log.warnf("%s '%s' not found in the %1s section", endpointType, requestedEndpoint);
+            log.warnf("%s '%s' not found in the %s section", endpointType, requestedEndpoint, clowderKey.substring(0, clowderKey.length() - 1));
             return null;
         }
 


### PR DESCRIPTION
I noticed that we were getting a (harmless) logging exception thrown upon startup of our runtimes-inventory pods. It seems this is caused by us referencing a missing endpoint in our application.properties. The problem below seems to be trying to use a `%1s` format specifier.

To fix this bug, I used the `clowderKey` with the final `.` stripped off, e.g.:
`Endpoint 'sources-api-svc' not found in the clowder.endpoints section`

Test output before fix:
```
[INFO] Running com.redhat.cloud.common.clowder.configsource.ConfigSourceTest
2023-10-11 17:47:32,129 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'unknown' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]
LogManager error of type FORMAT_FAILURE: Formatting error
java.util.MissingFormatArgumentException: Format specifier '%1s'
	at java.base/java.util.Formatter.format(Formatter.java:2688)
	at java.base/java.util.Formatter.format(Formatter.java:2625)
	at java.base/java.lang.String.format(String.java:4145)
	at org.jboss.logmanager.ExtFormatter.formatMessagePrintf(ExtFormatter.java:118)
	at org.jboss.logmanager.ExtFormatter.formatMessage(ExtFormatter.java:65)
	at org.jboss.logmanager.formatters.Formatters$16.renderRaw(Formatters.java:781)
	at org.jboss.logmanager.formatters.Formatters$JustifyingFormatStep.render(Formatters.java:221)
	at org.jboss.logmanager.formatters.MultistepFormatter.format(MultistepFormatter.java:86)
	at org.jboss.logmanager.ExtFormatter.format(ExtFormatter.java:32)
	at org.jboss.logmanager.handlers.WriterHandler.doPublish(WriterHandler.java:43)
	at org.jboss.logmanager.ExtHandler.publish(ExtHandler.java:66)
	at org.jboss.logmanager.ExtHandler.publishToNestedHandlers(ExtHandler.java:97)
	at io.quarkus.bootstrap.logging.QuarkusDelayedHandler.doPublish(QuarkusDelayedHandler.java:81)
	at org.jboss.logmanager.ExtHandler.publish(ExtHandler.java:66)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:327)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:334)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:334)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:334)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:334)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:334)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:334)
	at org.jboss.logmanager.LoggerNode.publish(LoggerNode.java:334)
	at org.jboss.logmanager.Logger.logRaw(Logger.java:750)
	at org.jboss.logmanager.Logger.log(Logger.java:708)
	at org.jboss.logging.JBossLogManagerLogger.doLogf(JBossLogManagerLogger.java:56)
	at org.jboss.logging.Logger.warnf(Logger.java:1420)
	at com.redhat.cloud.common.clowder.configsource.ClowderConfigSource.processEndpoints(ClowderConfigSource.java:441)
	at com.redhat.cloud.common.clowder.configsource.ClowderConfigSource.getValue(ClowderConfigSource.java:337)
	at com.redhat.cloud.common.clowder.configsource.ConfigSourceTest.testUnknownClowderEndpoint(ConfigSourceTest.java:213)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:727)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:156)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:147)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:86)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(InterceptingExecutableInvoker.java:103)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.lambda$invoke$0(InterceptingExecutableInvoker.java:93)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:92)
	at org.junit.jupiter.engine.execution.InterceptingExecutableInvoker.invoke(InterceptingExecutableInvoker.java:86)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:217)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:213)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:138)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:68)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)
2023-10-11 17:47:32,162 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.url" configuration key
2023-10-11 17:47:32,162 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.trust-store-path" configuration key
2023-10-11 17:47:32,163 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.trust-store-password" configuration key
2023-10-11 17:47:32,163 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.trust-store-type" configuration key
2023-10-11 17:47:32,219 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-engine.url" configuration key
2023-10-11 17:47:32,256 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.url" configuration key
2023-10-11 17:47:32,301 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'notifications-api' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]
2023-10-11 17:47:32,301 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'notifications-gw' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]
2023-10-11 17:47:32,317 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.url" configuration key
2023-10-11 17:47:32,317 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.trust-store-path" configuration key
2023-10-11 17:47:32,318 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.trust-store-password" configuration key
2023-10-11 17:47:32,318 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.trust-store-type" configuration key
```

Test output after fix:
```
[INFO] Running com.redhat.cloud.common.clowder.configsource.ConfigSourceTest
2023-10-11 18:05:04,312 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'unknown' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]
2023-10-11 18:05:04,312 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'unknown' not found in the clowder.endpoints section
2023-10-11 18:05:04,341 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.url" configuration key
2023-10-11 18:05:04,342 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.trust-store-path" configuration key
2023-10-11 18:05:04,342 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.trust-store-password" configuration key
2023-10-11 18:05:04,342 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.trust-store-type" configuration key
2023-10-11 18:05:04,397 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-engine.url" configuration key
2023-10-11 18:05:04,428 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No endpoints section found. Returning empty string for the "clowder.optional-endpoints.notifications-api.url" configuration key
2023-10-11 18:05:04,429 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'non-existent' not found in the clowder.optional-endpoints section
2023-10-11 18:05:04,436 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Private endpoint 'non-existent' not found in the clowder.optional-private-endpoints section
2023-10-11 18:05:04,462 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'notifications-api' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]
2023-10-11 18:05:04,462 WARN  [com.red.clo.com.clo.con.ClowderConfigSource] (main) Endpoint 'notifications-gw' is using the old format. Please move to the new one: [Endpoint].[url|trust-store-path|trust-store-password|trust-store-type]
2023-10-11 18:05:04,475 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.url" configuration key
2023-10-11 18:05:04,475 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.trust-store-path" configuration key
2023-10-11 18:05:04,475 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.trust-store-password" configuration key
2023-10-11 18:05:04,475 INFO  [com.red.clo.com.clo.con.ClowderConfigSource] (main) No private endpoints section found. Returning empty string for the "clowder.optional-private-endpoints.notifications-api.trust-store-type" configuration key
```