### PR TITLE
feat: Resolve computed properties for Kafka topics

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/utils/ComputedPropertiesUtils.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/utils/ComputedPropertiesUtils.java
@@ -1,0 +1,98 @@
+package com.redhat.cloud.common.clowder.configsource.utils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Utilities to find computed properties. Computed properties are properties that depend on others. For example:
+ *
+ * <code>
+ * other.property=value-a
+ * computed.property=${other.property:value-b}
+ * </code>
+ *
+ * In the above example, the "computed-property" is resolved with either "other.property" if exists or "value-b"
+ * if it does not.
+ */
+public final class ComputedPropertiesUtils {
+
+    public static final String PROPERTY_START = "${";
+    public static final String PROPERTY_END = "}";
+
+    private ComputedPropertiesUtils() {
+
+    }
+
+    public static boolean hasComputedProperties(String rawValue) {
+        return isNotNullOrEmpty(rawValue) && rawValue.contains(PROPERTY_START);
+    }
+
+    public static String getPropertyFromSystem(String propertyName, String defaultValue) {
+        String value = Optional.ofNullable(System.getProperty(propertyName))
+                .orElseGet(() -> System.getenv(propertyName));
+
+        return isNullOrEmpty(value) ? defaultValue : value;
+    }
+
+    public static List<String> getComputedProperties(String str) {
+        if (isNullOrEmpty(str)) {
+            return Collections.emptyList();
+        }
+
+        int closeLen = PROPERTY_END.length();
+        int openLen = PROPERTY_START.length();
+        List<String> list = new ArrayList<>();
+        int end;
+        for (int pos = 0; pos < str.length() - closeLen; pos = end + closeLen) {
+            int start = str.indexOf(PROPERTY_START, pos);
+            if (start < 0) {
+                break;
+            }
+
+            start += openLen;
+            end = str.indexOf(PROPERTY_END, start);
+            if (end < 0) {
+                break;
+            }
+
+            String currentStr = str.substring(start);
+            String tentative = currentStr.substring(0, end - start);
+            while (countMatches(tentative, PROPERTY_START) != countMatches(tentative, PROPERTY_END)) {
+                end++;
+                if (end >= str.length()) {
+                    break;
+                }
+
+                tentative = currentStr.substring(0, end - start);
+            }
+
+            list.add(tentative);
+        }
+
+        return list;
+    }
+
+    private static int countMatches(String str, String sub) {
+        if (!isNullOrEmpty(str) && !isNullOrEmpty(sub)) {
+            int count = 0;
+
+            for (int idx = 0; (idx = str.indexOf(sub, idx)) != -1; idx += sub.length()) {
+                ++count;
+            }
+
+            return count;
+        } else {
+            return 0;
+        }
+    }
+
+    private static boolean isNotNullOrEmpty(String str) {
+        return !isNullOrEmpty(str);
+    }
+
+    private static boolean isNullOrEmpty(String str) {
+        return str == null || str.isEmpty();
+    }
+}

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -102,6 +102,30 @@ public class ConfigSourceTest {
     }
 
     @Test
+    void testKafkaOutgoingWithSystemProperty() {
+        String topic = ccs.getValue("mp.messaging.outgoing.system.topic");
+        assertEquals("platform-system-property", topic);
+    }
+
+    @Test
+    void testKafkaOutgoingWithNestedSystemProperty() {
+        String topic = ccs.getValue("mp.messaging.outgoing.nested-properties.topic");
+        assertEquals("platform-nested-properties", topic);
+    }
+
+    @Test
+    void testKafkaIncomingWithComputedProperty() {
+        String topic = ccs.getValue("mp.messaging.incoming.computed.topic");
+        assertEquals("platform-computed-property", topic);
+    }
+
+    @Test
+    void testKafkaIncomingWithPartialComputedProperty() {
+        String topic = ccs.getValue("mp.messaging.incoming.partial-computed.topic");
+        assertEquals("platform-partial-computed-property", topic);
+    }
+
+    @Test
     void testDatabaseCredentials() {
         String user = ccs.getValue("quarkus.datasource.username");
         String pass = ccs.getValue("quarkus.datasource.password");

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -18,6 +18,21 @@ mp.messaging.incoming.ingress.group.id=integrations
 mp.messaging.incoming.ingress.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.incoming.ingress.value.serializer=org.apache.kafka.common.serialization.StringSerializer
 
+# System queue to test system properties
+mp.messaging.outgoing.system.connector=smallrye-kafka
+mp.messaging.outgoing.system.topic=${NO_EXIST:platform.notifications.system}
+nested.property.topic=nested-topic
+mp.messaging.outgoing.nested-properties.connector=smallrye-kafka
+mp.messaging.outgoing.nested-properties.topic=${NO_EXIST:${nested.property.topic}}
+
+# System queue to test properties defined in other keys
+custom.property.topic=custom-topic
+mp.messaging.incoming.computed.connector=smallrye-kafka
+mp.messaging.incoming.computed.topic=${custom.property.topic}
+
+mp.messaging.incoming.partial-computed.connector=smallrye-kafka
+mp.messaging.incoming.partial-computed.topic=partial-${custom.property.topic}-value
+
 # jdbc
 # configure your datasource
 quarkus.datasource.db-kind=postgresql

--- a/src/test/resources/cdappconfig.json
+++ b/src/test/resources/cdappconfig.json
@@ -38,6 +38,22 @@
       {
         "name": "platform-tmp-666",
         "requestedName": "platform.notifications.alerts"
+      },
+      {
+        "name": "platform-system-property",
+        "requestedName": "platform.notifications.system"
+      },
+      {
+        "name": "platform-computed-property",
+        "requestedName": "custom-topic"
+      },
+      {
+        "name": "platform-partial-computed-property",
+        "requestedName": "partial-custom-topic-value"
+      },
+      {
+        "name": "platform-nested-properties",
+        "requestedName": "nested-topic"
       }
     ]
   },


### PR DESCRIPTION
This pull request adds support to resolve computed or system properties that will be then used to get the actual value from the clowder config.

## Context

We want to configure topics using environmental properties, for example:

```
mp.messaging.outgoing.tasks-out.topic=${METERING_TASK_TOPIC}
```

So we can configure the service individually by providing the env var METERING_TASK_TOPIC. For example: "METERING_TASK_TOPIC=platform.rhsm-subscriptions.metering-tasks".

However, when using the above configuration, the clowder config tries to lookup for the topic with the requestedName "${METERING_TASK_TOPIC}" instead of "platform.rhsm-subscriptions.metering-tasks". 

With these changes, the clowder config is properly resolved using the request name "platform.rhsm-subscriptions.metering-tasks". 

## About computed properties
Computed properties are properties that depend on others. For example:

```
other.property=value-a
computed.property=${other.property:value-b}
```

In the above example, the "computed-property" is resolved with either "other.property" if exists or "value-b" if it does not.