### PR TITLE
feat: Be able to expose Kafka config keys from ClowderConfigSource

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -141,10 +141,10 @@ public class ClowderConfigSource implements ConfigSource {
 
         Set<String> availableProperties = new HashSet<>(existingValues.keySet());
 
-        if(exposeKafkaSslConfigKeys) {
-            for(String key : KAFKA_SASL_KEYS) {
+        if (exposeKafkaSslConfigKeys) {
+            for (String key : KAFKA_SASL_KEYS) {
                 String value = getValue(key);
-                if (value != null && value.trim().length()>0) {
+                if (value != null && !value.isBlank()) {
                     availableProperties.add(key);
                 }
             }

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
@@ -27,13 +27,18 @@ public class ClowderConfigSourceFactory implements ConfigSourceFactory {
     public Iterable<ConfigSource> getConfigSources(ConfigSourceContext configSourceContext) {
 
         ConfigValue cv = configSourceContext.getValue("acg.config");
-        String clowderConfig;
+        ConfigValue exposeKafkaSslConfigKeysCv = configSourceContext.getValue("acg.config.expose.kafka.ssl.config.keys");
+        String clowderConfig = "/cdapp/cdappconfig.json";
+        boolean exposeKafkaSslConfigKeys = false;
         if (cv != null && cv.getValue() != null) {
             clowderConfig = cv.getValue();
-        } else {
-            clowderConfig = "/cdapp/cdappconfig.json";
         }
         log.info("Using ClowderConfigSource with config at " + clowderConfig);
+
+        if (exposeKafkaSslConfigKeysCv != null && exposeKafkaSslConfigKeysCv.getValue() != null) {
+            exposeKafkaSslConfigKeys = Boolean.valueOf(exposeKafkaSslConfigKeysCv.getValue());
+        }
+        log.info("Expose Kafka config keys: " + exposeKafkaSslConfigKeys);
 
         // It should be used, so get the existing key-values and
         // supply them to our source.
@@ -57,7 +62,7 @@ public class ClowderConfigSourceFactory implements ConfigSourceFactory {
             }
         });
 
-        return Collections.singletonList(new ClowderConfigSource(clowderConfig, exProp));
+        return Collections.singletonList(new ClowderConfigSource(clowderConfig, exProp, exposeKafkaSslConfigKeys));
     }
 
     @Override

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
@@ -27,7 +27,7 @@ public class ClowderConfigSourceFactory implements ConfigSourceFactory {
     public Iterable<ConfigSource> getConfigSources(ConfigSourceContext configSourceContext) {
 
         ConfigValue cv = configSourceContext.getValue("acg.config");
-        ConfigValue exposeKafkaSslConfigKeysCv = configSourceContext.getValue("acg.config.expose.kafka.ssl.config.keys");
+        ConfigValue exposeKafkaSslConfigKeysCv = configSourceContext.getValue("feature-flags.expose-kafka-ssl-config-keys.enabled");
         String clowderConfig = "/cdapp/cdappconfig.json";
         boolean exposeKafkaSslConfigKeys = false;
         if (cv != null && cv.getValue() != null) {


### PR DESCRIPTION
From Quarkus 3.5.x, properties loading order seems have change to initialise kafka plugin.
Since we need to expose Kafka config keys (when they exists) from  method `public Set<String> getPropertyNames()`.