### PR TITLE
Refactor config source to not keep in memory all the properties

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -1,8 +1,7 @@
 package com.redhat.cloud.common.clowder.configsource;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.common.clowder.configsource.handlers.ClowderPropertyHandler;
 import io.smallrye.config.ConfigValue;
-import java.util.HashSet;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.logging.Logger;
 
@@ -10,10 +9,8 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -29,10 +26,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.redhat.cloud.common.clowder.configsource.utils.CertUtils.createTempFile;
 import static com.redhat.cloud.common.clowder.configsource.utils.ComputedPropertiesUtils.PROPERTY_END;
 import static com.redhat.cloud.common.clowder.configsource.utils.ComputedPropertiesUtils.PROPERTY_START;
-import static com.redhat.cloud.common.clowder.configsource.utils.ComputedPropertiesUtils.getPropertyFromSystem;
 import static com.redhat.cloud.common.clowder.configsource.utils.ComputedPropertiesUtils.getComputedProperties;
+import static com.redhat.cloud.common.clowder.configsource.utils.ComputedPropertiesUtils.getPropertyFromSystem;
 import static com.redhat.cloud.common.clowder.configsource.utils.ComputedPropertiesUtils.hasComputedProperties;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -42,94 +40,49 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class ClowderConfigSource implements ConfigSource {
 
     public static final String CLOWDER_CONFIG_SOURCE = "ClowderConfigSource";
-
-    // Kafka config keys.
-    public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
-    public static final String KAFKA_SASL_JAAS_CONFIG_KEY = "kafka.sasl.jaas.config";
-    public static final String KAFKA_SASL_MECHANISM_KEY = "kafka.sasl.mechanism";
-    public static final String KAFKA_SECURITY_PROTOCOL_KEY = "kafka.security.protocol";
-    public static final String KAFKA_SSL_TRUSTSTORE_LOCATION_KEY = "kafka.ssl.truststore.location";
-    public static final String KAFKA_SSL_TRUSTSTORE_TYPE_KEY = "kafka.ssl.truststore.type";
-
-    // Camel Kafka config keys.
-    public static final String CAMEL_KAFKA_BROKERS = "camel.component.kafka.brokers";
-    public static final String CAMEL_KAFKA_SASL_JAAS_CONFIG_KEY = "camel.component.kafka.sasl-jaas-config";
-    public static final String CAMEL_KAFKA_SASL_MECHANISM_KEY = "camel.component.kafka.sasl-mechanism";
-    public static final String CAMEL_KAFKA_SECURITY_PROTOCOL_KEY = "camel.component.kafka.security-protocol";
-    public static final String CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY = "camel.component.kafka.ssl-truststore-location";
-    public static final String CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY = "camel.component.kafka.ssl-truststore-type";
-
-    // Kafka SASL config values.
-    public static final String KAFKA_SSL_TRUSTSTORE_TYPE_VALUE = "PEM";
-
-    private static final String QUARKUS_LOG_CLOUDWATCH = "quarkus.log.cloudwatch";
-    private static final String QUARKUS_DATASOURCE_JDBC_URL = "quarkus.datasource.jdbc.url";
-    private static final String CLOWDER_ENDPOINTS = "clowder.endpoints.";
-    private static final String CLOWDER_PRIVATE_ENDPOINTS = "clowder.private-endpoints.";
-    private static final String CLOWDER_OPTIONAL_ENDPOINTS = "clowder.optional-endpoints.";
-    private static final String CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS = "clowder.optional-private-endpoints.";
-    private static final String CLOWDER_ENDPOINTS_PARAM_URL = "url";
-    private static final String CLOWDER_ENDPOINT_STORE_TYPE = "PKCS12";
-    private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH = "trust-store-path";
-    private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PASSWORD = "trust-store-password";
-    private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_TYPE = "trust-store-type";
-    private static List<String> KAFKA_SASL_KEYS = List.of(
-            KAFKA_SASL_JAAS_CONFIG_KEY,
-            KAFKA_SASL_MECHANISM_KEY,
-            KAFKA_SECURITY_PROTOCOL_KEY,
-            KAFKA_SSL_TRUSTSTORE_LOCATION_KEY,
-            KAFKA_SSL_TRUSTSTORE_TYPE_KEY,
-            CAMEL_KAFKA_SASL_JAAS_CONFIG_KEY,
-            CAMEL_KAFKA_SASL_MECHANISM_KEY,
-            CAMEL_KAFKA_SECURITY_PROTOCOL_KEY,
-            CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY,
-            CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY
-    );
-    // Fixed length for the password used - it could probably be anything else - but ran my tests on a FIPS environment with these.
+    private static final String CLOWDER_CERTIFICATE_STORE_TYPE = "PKCS12";
     private static final int DEFAULT_PASSWORD_LENGTH = 33;
-    private static final Integer PORT_NOT_SET = 0;
     private static final String PROPERTY_DEFAULT = ":";
-    private static final String QUARKUS_UNLEASH = "quarkus.unleash.";
+    private static final Logger LOG = Logger.getLogger(ClowderConfigSource.class.getName());
 
-    Logger log = Logger.getLogger(getClass().getName());
+    private final ClowderConfig root;
     private final Map<String, ConfigValue> existingValues;
-    private ClowderConfig root;
-    private boolean translate = true;
+    private final List<ClowderPropertyHandler> handlers;
 
     private String trustStorePath;
     private String trustStorePassword;
 
-    private boolean exposeKafkaSslConfigKeys;
-
     /**
      * <p>Constructor for ClowderConfigSource.</p>
      *
-     * @param configFile               Name/Path of a file to read the config from.
+     * @param root                     The clowder config.
      * @param exProp                   {@link Map} containing the existing properties from e.g. application.properties.
-     * @param exposeKafkaSslConfigKeys
+     * @param handlers
      */
-    public ClowderConfigSource(String configFile, Map<String, ConfigValue> exProp, boolean exposeKafkaSslConfigKeys) {
+    public ClowderConfigSource(ClowderConfig root, Map<String, ConfigValue> exProp, List<ClowderPropertyHandler> handlers) {
+        this.root = root;
+        this.existingValues = exProp;
+        this.handlers = handlers;
 
-        existingValues = exProp;
-        this.exposeKafkaSslConfigKeys = exposeKafkaSslConfigKeys;
-        File file = new File(configFile);
-        if (!file.canRead()) {
-            log.warn("Can't read clowder config from " + file.getAbsolutePath() + ", not doing translations.");
-            translate = false;
-        } else {
-            try {
-                String configJson = Files.readString(file.toPath());
-                root = new ObjectMapper().readValue(configJson, ClowderConfig.class);
-            } catch (IOException e) {
-                log.warn("Reading the clowder config failed, not doing translations", e);
-                translate = false;
+        // some handlers like KafkaSaslClowderPropertyHandler needs to populate extra properties that might
+        // not be initially set by the users. So, we need to automatically expose these extra properties and
+        // not overwrite them if it was already set by these users.
+        for (ClowderPropertyHandler handler : handlers) {
+            for (String property : handler.provides()) {
+                try {
+                    String value = getValue(property);
+                    if (value != null && !value.isBlank()) {
+                        existingValues.putIfAbsent(property, null);
+                    }
+                } catch (IllegalStateException ie) {
+                    LOG.debug(ie.getMessage());
+                }
             }
         }
     }
 
     @Override
     public Map<String, String> getProperties() {
-
         Map<String,String> props = new HashMap<>();
         Set<Map.Entry<String, ConfigValue>> entries = existingValues.entrySet();
         for (Map.Entry<String,ConfigValue> entry : entries) {
@@ -145,22 +98,7 @@ public class ClowderConfigSource implements ConfigSource {
 
     @Override
     public Set<String> getPropertyNames() {
-
-        Set<String> availableProperties = new HashSet<>(existingValues.keySet());
-
-        if (exposeKafkaSslConfigKeys) {
-            for (String key : KAFKA_SASL_KEYS) {
-                try {
-                    String value = getValue(key);
-                    if (value != null && !value.isBlank()) {
-                        availableProperties.add(key);
-                    }
-                } catch (IllegalStateException ie) {
-                    log.debug(ie.getMessage());
-                }
-            }
-        }
-        return availableProperties;
+        return existingValues.keySet();
     }
 
     @Override
@@ -179,374 +117,13 @@ public class ClowderConfigSource implements ConfigSource {
      */
     @Override
     public String getValue(String configKey) {
-
-        // This matches against the property as in application.properties
-        // For profiles != prod, values are requested first like
-        // %<profile>.property. E.g. %dev.quarkus.http.port
-
-        if (translate) {
-
-            if (configKey.equals("quarkus.http.port")) {
-                return String.valueOf(root.webPort);
-            }
-            if (configKey.equals(KAFKA_BOOTSTRAP_SERVERS) || configKey.equals(CAMEL_KAFKA_BROKERS)) {
-                if (root.kafka == null) {
-                    throw new IllegalStateException("Kafka base object not present, can't set Kafka values");
-                }
-                StringBuilder sb = new StringBuilder();
-                for (BrokerConfig broker: root.kafka.brokers) {
-                    if (sb.length() > 0) {
-                        sb.append(',');
-                    }
-                    sb.append(broker.hostname + ":" + broker.port);
-                }
-                return sb.toString();
-            }
-
-            if (configKey.startsWith("mp.messaging") && configKey.endsWith(".topic")) {
-                if (root.kafka == null) {
-                    throw new IllegalStateException("Kafka base object not present, can't set Kafka values");
-                }
-                // We need to find the replaced topic by first finding
-                // the requested name and then getting the replaced name
-                String requested = resolveValue(existingValues.get(configKey).getValue());
-                for (TopicConfig topic : root.kafka.topics) {
-                    if (topic.requestedName.equals(requested)) {
-                        return topic.name;
-                    }
-                }
-                return requested;
-            }
-
-            if (KAFKA_SASL_KEYS.contains(configKey)) {
-                if (root.kafka == null) {
-                    throw new IllegalStateException("Kafka base object not present, can't set Kafka values");
-                }
-                Optional<BrokerConfig> saslBroker = root.kafka.brokers.stream()
-                        .filter(broker -> "sasl".equals(broker.authtype))
-                        .findAny();
-
-                if (saslBroker.isPresent()) {
-                    switch (configKey) {
-                        case KAFKA_SASL_JAAS_CONFIG_KEY:
-                        case CAMEL_KAFKA_SASL_JAAS_CONFIG_KEY:
-                            String username = saslBroker.get().sasl.username;
-                            String password = saslBroker.get().sasl.password;
-                            switch (saslBroker.get().sasl.saslMechanism) {
-                                case "PLAIN":
-                                    return "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
-                                case "SCRAM-SHA-512":
-                                    return "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
-                            }
-                        case KAFKA_SASL_MECHANISM_KEY:
-                        case CAMEL_KAFKA_SASL_MECHANISM_KEY:
-                            return saslBroker.get().sasl.saslMechanism;
-                        case KAFKA_SECURITY_PROTOCOL_KEY:
-                        case CAMEL_KAFKA_SECURITY_PROTOCOL_KEY:
-                            return saslBroker.get().sasl.securityProtocol;
-                        case KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
-                        case CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
-                            return createTempKafkaCertFile(saslBroker.get().cacert);
-                        case KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
-                        case CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
-                            return KAFKA_SSL_TRUSTSTORE_TYPE_VALUE;
-                        default:
-                            throw new IllegalStateException(String.format("Config key: '%s' shouldn't be present for a Kafka SASL configuration, please check your config file", configKey));
-                    }
-                } else {
-                    Optional<BrokerConfig> sslBroker = root.kafka.brokers.stream()
-                        .filter(broker -> "SSL".equals(broker.securityProtocol))
-                        .findAny();
-                    if (sslBroker.isPresent()) {
-                        switch (configKey) {
-                            case KAFKA_SECURITY_PROTOCOL_KEY:
-                            case CAMEL_KAFKA_SECURITY_PROTOCOL_KEY:
-                                return sslBroker.get().securityProtocol;
-                            case KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
-                            case CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
-                                 return createTempKafkaCertFile(sslBroker.get().cacert);
-                            case KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
-                            case CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
-                                if(null != getValue(KAFKA_SSL_TRUSTSTORE_LOCATION_KEY)) {
-                                    return KAFKA_SSL_TRUSTSTORE_TYPE_VALUE;
-                                }
-                            default:
-                                throw new IllegalStateException(String.format("Config key: '%s' shouldn't be present for a Kafka SSL configuration, please check your config file", configKey));
-                       }
-                    }
-                }
-            }
-
-            if (configKey.startsWith("quarkus.datasource")) {
-                String item = configKey.substring("quarkus.datasource.".length());
-                if (root.database == null) {
-                    throw new IllegalStateException("No database section found");
-                }
-                if (item.equals("username")) {
-                    return root.database.username;
-                }
-                String sslMode = root.database.sslMode;
-                boolean useSsl = !sslMode.equals("disable");
-                boolean verifyFull = sslMode.equals("verify-full");
-
-                if (item.equals("password")) {
-                    return root.database.password;
-                }
-                if (item.equals("jdbc.url")) {
-                    String hostPortDb = getHostPortDb(root.database);
-                    String tracing = "";
-                    if (existingValues.containsKey(QUARKUS_DATASOURCE_JDBC_URL)) {
-                        String url = existingValues.get(QUARKUS_DATASOURCE_JDBC_URL).getValue();
-                        if (url.contains(":tracing:")) {
-                            // TODO Remove this block (tracing) later.
-                            log.warn("The support of OpenTracing in this library is deprecated and will be removed soon. Please consider switching to OpenTelemetry.");
-                            tracing = "tracing:";
-                        } else if (url.contains(":otel:")) {
-                            /*
-                             * The existing JDBC URL is the one coming from the application.properties file.
-                             * If that URL contains "otel" then it means that the app is able to connect to
-                             * the database through the OpenTelemetry JDBC layer.
-                             */
-                            tracing = "otel:";
-                        }
-                    }
-                    String jdbcUrl = String.format("jdbc:%s%s", tracing, hostPortDb);
-                    if (useSsl) {
-                        jdbcUrl = jdbcUrl + "?sslmode=" + sslMode;
-                    }
-                    if (verifyFull) {
-                        jdbcUrl = jdbcUrl + "&sslrootcert=" + createTempRdsCertFile(root.database.rdsCa);
-                    }
-                    return jdbcUrl;
-                }
-                if (item.startsWith("reactive.")) {
-                    if (item.equals("reactive.url")) {
-                        return getHostPortDb(root.database);
-                    }
-                    if (item.equals("reactive.postgresql.ssl-mode")) {
-                        return sslMode;
-                    }
-                    if (verifyFull) {
-                        if (item.equals("reactive.hostname-verification-algorithm")) {
-                            return "HTTPS";
-                        }
-                        if (item.equals("reactive.trust-certificate-pem")) {
-                            return "true";
-                        }
-                        if (item.equals("reactive.trust-certificate-pem.certs")) {
-                            return createTempRdsCertFile(root.database.rdsCa);
-                        }
-                    }
-                }
-            }
-
-            if (configKey.startsWith(QUARKUS_LOG_CLOUDWATCH)) {
-                if (root.logging == null) {
-                    throw new IllegalStateException("No logging section found");
-                }
-                if (root.logging.cloudwatch == null) {
-                    throw new IllegalStateException("No cloudwatch section found in logging object");
-                }
-
-                // Check for not null type and not "null" provider to enable and read
-                // cloudwatch properties from Clowder config.
-                // Note that the "null" type is a Clowder logging provider that disables
-                // central logging.
-                // Empty string type has to be treated as cloudwatch, as one of the Clowder
-                // logging providers (appinterface) did not set it correctly.
-                if (root.logging.type != null && !root.logging.type.equals("null")) {
-                    int prefixLen = QUARKUS_LOG_CLOUDWATCH.length();
-                    String sub = configKey.substring(prefixLen+1);
-                    switch (sub) {
-                        case "access-key-id":
-                            return root.logging.cloudwatch.accessKeyId;
-                        case "access-key-secret":
-                            return root.logging.cloudwatch.secretAccessKey;
-                        case "region":
-                            return root.logging.cloudwatch.region;
-                        case "log-group":
-                            return root.logging.cloudwatch.logGroup;
-                        default:
-                            // fall through to fetching the value from application.properties
-                    }
-                } else {
-                    // treat null logging type as disabled CloudWatch logging
-                    if (configKey.equals(QUARKUS_LOG_CLOUDWATCH + ".enabled")) {
-                        return "false";
-                    }
-                }
-            }
-
-            if (configKey.startsWith(CLOWDER_ENDPOINTS)) {
-                try {
-                    if (root.endpoints == null) {
-                        throw new IllegalStateException("No endpoints section found");
-                    }
-
-                    return this.processEndpoints(this.root.endpoints, configKey, CLOWDER_ENDPOINTS, "Endpoint");
-                } catch (IllegalStateException e) {
-                    log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
-                    throw e;
-                }
-            }
-
-            if (configKey.startsWith(CLOWDER_OPTIONAL_ENDPOINTS)) {
-                try {
-                    if (root.endpoints == null) {
-                        log.infof("No endpoints section found. Returning empty string for the \"%s\" configuration key", configKey);
-                        return "";
-                    }
-
-                    return this.processEndpoints(this.root.endpoints, configKey, CLOWDER_OPTIONAL_ENDPOINTS, "Endpoint");
-                } catch (final IllegalStateException e) {
-                    log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
-                    throw e;
-                }
-            }
-
-            if (configKey.startsWith(CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS)) {
-                try {
-                    if (root.privateEndpoints == null) {
-                        log.infof("No private endpoints section found. Returning empty string for the \"%s\" configuration key", configKey);
-                        return "";
-                    }
-
-                    return this.processEndpoints(this.root.privateEndpoints, configKey, CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS, "Private endpoint");
-                } catch (IllegalStateException e) {
-                    log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
-                    throw e;
-                }
-            }
-
-            if (configKey.startsWith(CLOWDER_PRIVATE_ENDPOINTS)) {
-                try {
-                    if (root.privateEndpoints == null) {
-                        throw new IllegalStateException("No private endpoints section found");
-                    }
-
-                    return this.processEndpoints(this.root.privateEndpoints, configKey, CLOWDER_PRIVATE_ENDPOINTS, "Private endpoint");
-                } catch (IllegalStateException e) {
-                    log.errorf("Failed to load config key '%s' from the Clowder configuration: %s", configKey, e.getMessage());
-                    throw e;
-                }
-            }
-
-            if (configKey.startsWith(QUARKUS_UNLEASH)) {
-                if (root.featureFlags == null) {
-                    log.warn("Unleash configuration requested by Quarkus but not found the Clowder configuration");
-                } else {
-                    String item = configKey.substring(QUARKUS_UNLEASH.length());
-                    if (item.equals("token")) {
-                        return root.featureFlags.clientAccessToken;
-                    }
-                    if (item.equals("url")) {
-                        String url = String.format("%s://%s", root.featureFlags.scheme, root.featureFlags.hostname);
-                        if (root.featureFlags.port != null) {
-                            url += ":" + root.featureFlags.port;
-                        }
-                        url += "/api";
-                        return url;
-                    }
-                }
+        for (ClowderPropertyHandler handler : handlers) {
+            if (handler.handles(configKey)) {
+                return handler.handle(configKey, this);
             }
         }
 
-        if (existingValues.containsKey(configKey)) {
-            return existingValues.get(configKey).getValue();
-        }
-        else {
-            return null;
-        }
-    }
-
-    /**
-     * Attempts to find the corresponding value for the provided configuration
-     * key. If the URL parameter has been requested, then depending on whether
-     * the endpoint has a TLS port or not, a full URL including the protocol
-     * is returned. For the rest of parameters it returns the corresponding
-     * value.
-     * @param endpointConfigs the list of configurations to be looked for the
-     *                        corresponding value.
-     * @param configKey       the configuration key specified in the
-     *                        "application.properties" file.
-     * @param clowderKey      the Clowder key which represents the path to
-     *                        either the regular endpoints or the private
-     *                        endpoints.
-     * @param endpointType    the type of the endpoint which the function will
-     *                        process. Used mainly for error and log messages.
-     * @return a full URL including the protocol in the case of requesting an
-     * endpoint's URL parameter. Regular values for the rest of the parameters.
-     */
-    private String processEndpoints(final List<? extends EndpointConfig> endpointConfigs, final String configKey, final String clowderKey, final String endpointType) {
-        final String requestedEndpointConfig = configKey.substring(clowderKey.length());
-        final String[] configPath = requestedEndpointConfig.split("\\.");
-
-        final String requestedEndpoint;
-        final String param;
-        final String FORMAT_EXAMPLE = String.format("[%s].[url|trust-store-path|trust-store-password|trust-store-type]", endpointType);
-        if (configPath.length == 1) {
-            log.warnf("%s '%s' is using the old format. Please move to the new one: %s", endpointType, requestedEndpointConfig, FORMAT_EXAMPLE);
-            requestedEndpoint = configPath[0];
-            param = CLOWDER_ENDPOINTS_PARAM_URL;
-        } else if (configPath.length != 2) {
-            throw new IllegalArgumentException(String.format("%s '%s' expects a different format: %s", endpointType, requestedEndpointConfig, FORMAT_EXAMPLE));
-        } else {
-            requestedEndpoint = configPath[0];
-            param = configPath[1];
-        }
-
-        EndpointConfig endpointConfig = null;
-
-        for (final EndpointConfig configCandidate : endpointConfigs) {
-            final String currentEndpoint = String.format("%s-%s", configCandidate.app, configCandidate.name);
-            if (currentEndpoint.equals(requestedEndpoint)) {
-                endpointConfig = configCandidate;
-                break;
-            }
-        }
-
-        if (endpointConfig == null) {
-            log.warnf("%s '%s' not found in the %s section", endpointType, requestedEndpoint, clowderKey.substring(0, clowderKey.length() - 1));
-            return null;
-        }
-
-        switch (param) {
-            case CLOWDER_ENDPOINTS_PARAM_URL:
-                if (usesTls(endpointConfig)) {
-                    return String.format("https://%s:%s", endpointConfig.hostname, endpointConfig.tlsPort);
-                } else {
-                    return String.format("http://%s:%s", endpointConfig.hostname, endpointConfig.port);
-                }
-            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH:
-                if (usesTls(endpointConfig)) {
-                    ensureTlsCertPathIsPresent();
-
-                    createTruststoreFile(this.root.tlsCAPath);
-                    return this.trustStorePath;
-                }
-
-                return null;
-            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PASSWORD:
-                if (usesTls(endpointConfig)) {
-                    ensureTlsCertPathIsPresent();
-
-                    createTruststoreFile(this.root.tlsCAPath);
-                    return this.trustStorePassword;
-                }
-
-                return null;
-            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_TYPE:
-                if (usesTls(endpointConfig)) {
-                    ensureTlsCertPathIsPresent();
-
-                    return CLOWDER_ENDPOINT_STORE_TYPE;
-                }
-
-                return null;
-            default:
-                log.warnf("%s '%s' requested an unknown param: '%s'", endpointType, requestedEndpoint, param);
-                return null;
-        }
+        return getExistingValue(configKey);
     }
 
     @Override
@@ -554,30 +131,41 @@ public class ClowderConfigSource implements ConfigSource {
         return CLOWDER_CONFIG_SOURCE;
     }
 
-    private String getHostPortDb(DatabaseConfig database) {
-        return String.format("postgresql://%s:%d/%s",
-                database.hostname,
-                database.port,
-                database.name);
+    public Logger getLogger() {
+        return LOG;
     }
 
-    private boolean usesTls(EndpointConfig endpointConfig) {
-        return endpointConfig.tlsPort != null && !endpointConfig.tlsPort.equals(PORT_NOT_SET);
+    public String getExistingValue(String configKey) {
+        return Optional.ofNullable(this.existingValues.get(configKey))
+                .map(c -> resolveValue(c.getValue()))
+                .orElse(null);
     }
 
-    private void ensureTlsCertPathIsPresent() {
-        if (root.tlsCAPath == null || root.tlsCAPath.isBlank()) {
-            throw new IllegalStateException("Requested tls port for endpoint but did not provide tlsCAPath");
+    public String getTrustStorePassword() {
+        if (trustStorePassword == null) {
+            initializeTrustStoreCertificate();
         }
+
+        return trustStorePassword;
     }
 
-    private void createTruststoreFile(String certPath) {
-        if (this.trustStorePath != null) {
-            return;
+    public String getTrustStorePath() {
+        if (trustStorePath == null) {
+            initializeTrustStoreCertificate();
         }
+
+        return trustStorePath;
+    }
+
+    public String getTrustStoreType() {
+        return CLOWDER_CERTIFICATE_STORE_TYPE;
+    }
+
+    private void initializeTrustStoreCertificate() {
+        ensureTlsCertPathIsPresent();
 
         try {
-            String certContent = Files.readString(new File(certPath).toPath(), UTF_8);
+            String certContent = Files.readString(new File(root.tlsCAPath).toPath(), UTF_8);
             List<String> base64Certs = readCerts(certContent);
 
             List<X509Certificate> certificates = parsePemCert(base64Certs)
@@ -592,7 +180,7 @@ public class ClowderConfigSource implements ConfigSource {
             // Generate a keystore by hand
             // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/security/KeyStore.html
 
-            KeyStore truststore = KeyStore.getInstance(CLOWDER_ENDPOINT_STORE_TYPE);
+            KeyStore truststore = KeyStore.getInstance(CLOWDER_CERTIFICATE_STORE_TYPE);
 
             // Per the docs, we need to init the new keystore with load(null)
             truststore.load(null);
@@ -610,6 +198,12 @@ public class ClowderConfigSource implements ConfigSource {
             throw new IllegalStateException("Couldn't load the keystore format PKCS12", kse);
         } catch (NoSuchAlgorithmException | CertificateException ce) {
             throw new IllegalStateException("Couldn't configure the keystore", ce);
+        }
+    }
+
+    private void ensureTlsCertPathIsPresent() {
+        if (root.tlsCAPath == null || root.tlsCAPath.isBlank()) {
+            throw new IllegalStateException("Requested tls port for endpoint but did not provide tlsCAPath");
         }
     }
 
@@ -660,42 +254,6 @@ public class ClowderConfigSource implements ConfigSource {
         char[] password = new char[size];
         seed.getChars(0, size, password, 0);
         return password;
-    }
-
-    private String createTempRdsCertFile(String certData) {
-        if (certData != null) {
-            return createTempCertFile("rds-ca-root", certData);
-        } else {
-            throw new IllegalStateException("'database.sslMode' is set to 'verify-full' in the Clowder config but the 'database.rdsCa' field is missing");
-        }
-    }
-
-    private String createTempKafkaCertFile(String certData) {
-        if (certData != null) {
-            return createTempCertFile("kafka-cacert", certData);
-        } else {
-            return null;
-        }
-    }
-
-    private String createTempCertFile(String fileName, String certData) {
-        byte[] cert = certData.getBytes(UTF_8);
-        try {
-            File certFile = createTempFile(fileName, ".crt");
-            return Files.write(Path.of(certFile.getAbsolutePath()), cert).toString();
-        } catch (IOException e) {
-            throw new UncheckedIOException("Certificate file creation failed", e);
-        }
-    }
-
-    private File createTempFile(String fileName, String suffix) throws IOException {
-        File file = File.createTempFile(fileName, suffix);
-        try {
-            file.deleteOnExit();
-        } catch (SecurityException e) {
-            log.warnf(e, "Delete on exit of the '%s' cert file denied by the security manager", fileName);
-        }
-        return file;
     }
 
     private String resolveValue(String property) {

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
@@ -1,14 +1,31 @@
 package com.redhat.cloud.common.clowder.configsource;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.cloud.common.clowder.configsource.handlers.ClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.EndpointsClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.KafkaBootstrapServersClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.KafkaSecurityClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.MicroprofileMessagingClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.OptionalEndpointsClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.OptionalPrivateEndpointsClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.PrivateEndpointsClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.QuarkusDataSourceClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.QuarkusLogCloudWatchClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.QuarkusUnleashClowderPropertyHandler;
+import com.redhat.cloud.common.clowder.configsource.handlers.WebPortClowderPropertyHandler;
 import io.smallrye.config.ConfigSourceContext;
 import io.smallrye.config.ConfigSourceFactory;
 import io.smallrye.config.ConfigValue;
 import org.eclipse.microprofile.config.spi.ConfigSource;
 import org.jboss.logging.Logger;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
 
@@ -21,48 +38,24 @@ import static io.smallrye.config.Expressions.withoutExpansion;
  */
 public class ClowderConfigSourceFactory implements ConfigSourceFactory {
 
-    Logger log = Logger.getLogger(getClass().getName());
+    private static final Logger LOG = Logger.getLogger(ClowderConfigSourceFactory.class.getName());
 
     @Override
     public Iterable<ConfigSource> getConfigSources(ConfigSourceContext configSourceContext) {
-
         ConfigValue cv = configSourceContext.getValue("acg.config");
-        ConfigValue exposeKafkaSslConfigKeysCv = configSourceContext.getValue("feature-flags.expose-kafka-ssl-config-keys.enabled");
         String clowderConfig = "/cdapp/cdappconfig.json";
-        boolean exposeKafkaSslConfigKeys = false;
         if (cv != null && cv.getValue() != null) {
             clowderConfig = cv.getValue();
         }
-        log.info("Using ClowderConfigSource with config at " + clowderConfig);
 
-        if (exposeKafkaSslConfigKeysCv != null && exposeKafkaSslConfigKeysCv.getValue() != null) {
-            exposeKafkaSslConfigKeys = Boolean.valueOf(exposeKafkaSslConfigKeysCv.getValue());
+        File clowderConfigFile = new File(clowderConfig);
+        if (!clowderConfigFile.exists()) {
+            LOG.warn("Can't read clowder config from " + clowderConfigFile.getAbsolutePath() + ", not doing translations.");
+            return List.of();
         }
-        log.info("Expose Kafka config keys: " + exposeKafkaSslConfigKeys);
 
-        // It should be used, so get the existing key-values and
-        // supply them to our source.
-        Map<String, ConfigValue> exProp = new HashMap<>();
-        Iterator<String> stringIterator = configSourceContext.iterateNames();
-
-        /*
-         * A config value expansion happens when an expression wrapped into `${ }` is resolved.
-         * For example, if the configuration contains `foo=1234` and `bar=${foo}`, then `bar`
-         * will be resolved and expanded to the value `1234`.
-         * However, if an expression cannot be resolved because it refers to a missing config key,
-         * then the expansion fails and a NoSuchElementException is thrown.
-         * Such a throw should only happen when the config value is actually used and not here.
-         * That's why we need to disable the config values expansion.
-         */
-        withoutExpansion(() -> {
-            while (stringIterator.hasNext()) {
-                String key = stringIterator.next();
-                ConfigValue value = configSourceContext.getValue(key);
-                exProp.put(key, value);
-            }
-        });
-
-        return Collections.singletonList(new ClowderConfigSource(clowderConfig, exProp, exposeKafkaSslConfigKeys));
+        LOG.info("Using ClowderConfigSource with config at " + clowderConfig);
+        return loadClowderConfigFromFile(configSourceContext, clowderConfigFile);
     }
 
     @Override
@@ -70,5 +63,68 @@ public class ClowderConfigSourceFactory implements ConfigSourceFactory {
         // This is the order of factory evaluation in case there are multiple
         // factories.
         return OptionalInt.of(270);
+    }
+
+    public static List<ClowderPropertyHandler> loadPropertyHandlers(ClowderConfig root, boolean exposeKafkaSslConfigKeys) {
+        return List.of(new WebPortClowderPropertyHandler(root),
+                new KafkaBootstrapServersClowderPropertyHandler(root),
+                new KafkaSecurityClowderPropertyHandler(root, exposeKafkaSslConfigKeys),
+                new QuarkusDataSourceClowderPropertyHandler(root),
+                new QuarkusLogCloudWatchClowderPropertyHandler(root),
+                new EndpointsClowderPropertyHandler(root),
+                new OptionalEndpointsClowderPropertyHandler(root),
+                new OptionalPrivateEndpointsClowderPropertyHandler(root),
+                new PrivateEndpointsClowderPropertyHandler(root),
+                new MicroprofileMessagingClowderPropertyHandler(root),
+                new QuarkusUnleashClowderPropertyHandler(root));
+    }
+
+    private static List<ConfigSource> loadClowderConfigFromFile(ConfigSourceContext configSourceContext, File clowderConfigFile) {
+        ConfigValue exposeKafkaSslConfigKeysCv = configSourceContext.getValue("feature-flags.expose-kafka-ssl-config-keys.enabled");
+        boolean exposeKafkaSslConfigKeys = false;
+        if (exposeKafkaSslConfigKeysCv != null
+                && exposeKafkaSslConfigKeysCv.getValue() != null) {
+            exposeKafkaSslConfigKeys = Boolean.parseBoolean(exposeKafkaSslConfigKeysCv.getValue());
+        }
+
+        try {
+            String configJson = Files.readString(clowderConfigFile.toPath());
+            ClowderConfig root = new ObjectMapper().readValue(configJson, ClowderConfig.class);
+
+            LOG.info("Exposing Kafka config keys: " + exposeKafkaSslConfigKeys);
+            List<ClowderPropertyHandler> handlers = loadPropertyHandlers(root, exposeKafkaSslConfigKeys);
+
+            // It should be used, so get the existing key-values and
+            // supply them to our source.
+            Map<String, ConfigValue> exProp = new HashMap<>();
+            Iterator<String> stringIterator = configSourceContext.iterateNames();
+
+            /*
+             * A config value expansion happens when an expression wrapped into `${ }` is resolved.
+             * For example, if the configuration contains `foo=1234` and `bar=${foo}`, then `bar`
+             * will be resolved and expanded to the value `1234`.
+             * However, if an expression cannot be resolved because it refers to a missing config key,
+             * then the expansion fails and a NoSuchElementException is thrown.
+             * Such a throw should only happen when the config value is actually used and not here.
+             * That's why we need to disable the config values expansion.
+             */
+            withoutExpansion(() -> {
+                while (stringIterator.hasNext()) {
+                    String key = stringIterator.next();
+                    for (ClowderPropertyHandler handler : handlers) {
+                        if (handler.handles(key)) {
+                            ConfigValue value = configSourceContext.getValue(key);
+                            exProp.put(key, value);
+                            break;
+                        }
+                    }
+                }
+            });
+
+            return Collections.singletonList(new ClowderConfigSource(root, exProp, handlers));
+        } catch (IOException ex) {
+            LOG.warn("Reading the clowder config failed, not doing translations", ex);
+            return List.of();
+        }
     }
 }

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSourceFactory.java
@@ -49,7 +49,7 @@ public class ClowderConfigSourceFactory implements ConfigSourceFactory {
         }
 
         File clowderConfigFile = new File(clowderConfig);
-        if (!clowderConfigFile.exists()) {
+        if (!clowderConfigFile.canRead()) {
             LOG.warn("Can't read clowder config from " + clowderConfigFile.getAbsolutePath() + ", not doing translations.");
             return List.of();
         }

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/ClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/ClowderPropertyHandler.java
@@ -1,0 +1,26 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+import java.util.List;
+
+public abstract class ClowderPropertyHandler {
+
+    protected final ClowderConfig clowderConfig;
+
+    protected ClowderPropertyHandler(ClowderConfig clowderConfig) {
+        this.clowderConfig = clowderConfig;
+    }
+
+    public abstract boolean handles(String property);
+
+    public abstract String handle(String property, ClowderConfigSource configSource);
+
+    /**
+     * List of properties that this property handler exposes.
+     */
+    public List<String> provides() {
+        return List.of();
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/EndpointsClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/EndpointsClowderPropertyHandler.java
@@ -1,0 +1,126 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+import com.redhat.cloud.common.clowder.configsource.EndpointConfig;
+
+import java.util.List;
+
+public class EndpointsClowderPropertyHandler extends ClowderPropertyHandler {
+
+    private static final String CLOWDER_ENDPOINTS = "clowder.endpoints.";
+    private static final String CLOWDER_ENDPOINTS_PARAM_URL = "url";
+    private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH = "trust-store-path";
+    private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PASSWORD = "trust-store-password";
+    private static final String CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_TYPE = "trust-store-type";
+    private static final Integer PORT_NOT_SET = 0;
+
+    public EndpointsClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public boolean handles(String property) {
+        return property.startsWith(getPropertyEndpointKey());
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        try {
+            if (clowderConfig.endpoints == null) {
+                throw new IllegalStateException("No endpoints section found");
+            }
+
+            return processEndpoints(property, configSource, clowderConfig.endpoints, "Endpoint");
+        } catch (IllegalStateException e) {
+            configSource.getLogger().errorf("Failed to load config key '%s' from the Clowder configuration: %s", property, e.getMessage());
+            throw e;
+        }
+    }
+
+    protected String getPropertyEndpointKey() {
+        return CLOWDER_ENDPOINTS;
+    }
+
+    /**
+     * Attempts to find the corresponding value for the provided configuration
+     * key. If the URL parameter has been requested, then depending on whether
+     * the endpoint has a TLS port or not, a full URL including the protocol
+     * is returned. For the rest of parameters it returns the corresponding
+     * value.
+     * @param configKey       the configuration key specified in the
+     *                        "application.properties" file.
+     * @param endpointType    the type of the endpoint which the function will
+     *                        process. Used mainly for error and log messages.
+     * @return a full URL including the protocol in the case of requesting an
+     * endpoint's URL parameter. Regular values for the rest of the parameters.
+     */
+    protected String processEndpoints(String configKey, ClowderConfigSource configSource, List<? extends EndpointConfig> endpoints, String endpointType) {
+        final String clowderKey = getPropertyEndpointKey();
+        final String requestedEndpointConfig = configKey.substring(clowderKey.length());
+        final String[] configPath = requestedEndpointConfig.split("\\.");
+
+        final String requestedEndpoint;
+        final String param;
+        final String FORMAT_EXAMPLE = String.format("[%s].[url|trust-store-path|trust-store-password|trust-store-type]", endpointType);
+        if (configPath.length == 1) {
+            configSource.getLogger().warnf("%s '%s' is using the old format. Please move to the new one: %s", endpointType, requestedEndpointConfig, FORMAT_EXAMPLE);
+            requestedEndpoint = configPath[0];
+            param = CLOWDER_ENDPOINTS_PARAM_URL;
+        } else if (configPath.length != 2) {
+            throw new IllegalArgumentException(String.format("%s '%s' expects a different format: %s", endpointType, requestedEndpointConfig, FORMAT_EXAMPLE));
+        } else {
+            requestedEndpoint = configPath[0];
+            param = configPath[1];
+        }
+
+        EndpointConfig endpointConfig = null;
+
+        for (final EndpointConfig configCandidate : endpoints) {
+            final String currentEndpoint = String.format("%s-%s", configCandidate.app, configCandidate.name);
+            if (currentEndpoint.equals(requestedEndpoint)) {
+                endpointConfig = configCandidate;
+                break;
+            }
+        }
+
+        if (endpointConfig == null) {
+            configSource.getLogger().warnf("%s '%s' not found in the %s section", endpointType, requestedEndpoint, clowderKey.substring(0, clowderKey.length() - 1));
+            return null;
+        }
+
+        switch (param) {
+            case CLOWDER_ENDPOINTS_PARAM_URL:
+                if (usesTls(endpointConfig)) {
+                    return String.format("https://%s:%s", endpointConfig.hostname, endpointConfig.tlsPort);
+                } else {
+                    return String.format("http://%s:%s", endpointConfig.hostname, endpointConfig.port);
+                }
+            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PATH:
+                if (usesTls(endpointConfig)) {
+                    return configSource.getTrustStorePath();
+                }
+
+                return null;
+            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_PASSWORD:
+                if (usesTls(endpointConfig)) {
+                    return configSource.getTrustStorePassword();
+                }
+
+                return null;
+            case CLOWDER_ENDPOINTS_PARAM_TRUST_STORE_TYPE:
+                if (usesTls(endpointConfig)) {
+                    return configSource.getTrustStoreType();
+                }
+
+                return null;
+            default:
+                configSource.getLogger().warnf("%s '%s' requested an unknown param: '%s'", endpointType, requestedEndpoint, param);
+                return null;
+        }
+    }
+
+    private boolean usesTls(EndpointConfig endpointConfig) {
+        return endpointConfig.tlsPort != null && !endpointConfig.tlsPort.equals(PORT_NOT_SET);
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/KafkaBootstrapServersClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/KafkaBootstrapServersClowderPropertyHandler.java
@@ -1,0 +1,37 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.BrokerConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class KafkaBootstrapServersClowderPropertyHandler extends ClowderPropertyHandler {
+
+    private static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
+    private static final String CAMEL_KAFKA_BROKERS = "camel.component.kafka.brokers";
+
+    public KafkaBootstrapServersClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public boolean handles(String property) {
+        return property.equals(KAFKA_BOOTSTRAP_SERVERS) || property.equals(CAMEL_KAFKA_BROKERS);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        if (clowderConfig.kafka == null) {
+            throw new IllegalStateException("Kafka base object not present, can't set Kafka values");
+        } else {
+            StringBuilder sb = new StringBuilder();
+            for (BrokerConfig broker: clowderConfig.kafka.brokers) {
+                if (!sb.isEmpty()) {
+                    sb.append(',');
+                }
+                sb.append(broker.hostname).append(":").append(broker.port);
+            }
+
+            return sb.toString();
+        }
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/KafkaSecurityClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/KafkaSecurityClowderPropertyHandler.java
@@ -1,0 +1,154 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.BrokerConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.redhat.cloud.common.clowder.configsource.utils.CertUtils.createTempCertFile;
+
+public class KafkaSecurityClowderPropertyHandler extends ClowderPropertyHandler {
+
+    public static final String KAFKA_SASL_JAAS_CONFIG_KEY = "kafka.sasl.jaas.config";
+    public static final String KAFKA_SASL_MECHANISM_KEY = "kafka.sasl.mechanism";
+    public static final String KAFKA_SECURITY_PROTOCOL_KEY = "kafka.security.protocol";
+    public static final String KAFKA_SSL_TRUSTSTORE_LOCATION_KEY = "kafka.ssl.truststore.location";
+    public static final String KAFKA_SSL_TRUSTSTORE_TYPE_KEY = "kafka.ssl.truststore.type";
+    public static final String CAMEL_KAFKA_SASL_JAAS_CONFIG_KEY = "camel.component.kafka.sasl-jaas-config";
+    public static final String CAMEL_KAFKA_SASL_MECHANISM_KEY = "camel.component.kafka.sasl-mechanism";
+    public static final String CAMEL_KAFKA_SECURITY_PROTOCOL_KEY = "camel.component.kafka.security-protocol";
+    public static final String CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY = "camel.component.kafka.ssl-truststore-location";
+    public static final String CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY = "camel.component.kafka.ssl-truststore-type";
+    public static final String KAFKA_SSL_TRUSTSTORE_TYPE_VALUE = "PEM";
+    private static final List<String> KAFKA_SASL_KEYS = List.of(
+            KAFKA_SASL_JAAS_CONFIG_KEY,
+            KAFKA_SASL_MECHANISM_KEY,
+            KAFKA_SECURITY_PROTOCOL_KEY,
+            KAFKA_SSL_TRUSTSTORE_LOCATION_KEY,
+            KAFKA_SSL_TRUSTSTORE_TYPE_KEY,
+            CAMEL_KAFKA_SASL_JAAS_CONFIG_KEY,
+            CAMEL_KAFKA_SASL_MECHANISM_KEY,
+            CAMEL_KAFKA_SECURITY_PROTOCOL_KEY,
+            CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY,
+            CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY);
+
+    private static final List<String> KAFKA_SSL_KEYS = List.of(
+            KAFKA_SECURITY_PROTOCOL_KEY,
+            KAFKA_SSL_TRUSTSTORE_LOCATION_KEY,
+            KAFKA_SSL_TRUSTSTORE_TYPE_KEY,
+            CAMEL_KAFKA_SECURITY_PROTOCOL_KEY,
+            CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY,
+            CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY);
+
+    private final boolean expose;
+    private final Optional<BrokerConfig> saslBroker;
+    private final Optional<BrokerConfig> sslBroker;
+
+    public KafkaSecurityClowderPropertyHandler(ClowderConfig clowderConfig, boolean expose) {
+        super(clowderConfig);
+
+        this.expose = expose;
+        if (clowderConfig.kafka != null && clowderConfig.kafka.brokers != null) {
+            this.saslBroker = clowderConfig.kafka.brokers.stream()
+                    .filter(broker -> "sasl".equals(broker.authtype))
+                    .findAny();
+            this.sslBroker = clowderConfig.kafka.brokers.stream()
+                    .filter(broker -> "SSL".equals(broker.securityProtocol))
+                    .findAny();
+        } else {
+            this.saslBroker = Optional.empty();
+            this.sslBroker = Optional.empty();
+        }
+    }
+
+    @Override
+    public List<String> provides() {
+        if (expose) {
+            if (sslBroker.isPresent()) {
+                return KAFKA_SSL_KEYS;
+            } else if (saslBroker.isPresent()) {
+                return KAFKA_SASL_KEYS;
+            }
+        }
+
+        return List.of();
+    }
+
+    @Override
+    public boolean handles(String property) {
+        return KAFKA_SSL_KEYS.contains(property) || KAFKA_SASL_KEYS.contains(property);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        if (clowderConfig.kafka == null) {
+            throw new IllegalStateException("Kafka base object not present, can't set Kafka values");
+        }
+
+        if (saslBroker.isPresent()) {
+            return handleKafkaSaslKey(property, configSource);
+        } else if (sslBroker.isPresent()) {
+            return handleKafkaSslKey(property, configSource);
+        }
+
+        return configSource.getExistingValue(property);
+    }
+
+    private String handleKafkaSaslKey(String property, ClowderConfigSource configSource) {
+        switch (property) {
+            case KAFKA_SASL_JAAS_CONFIG_KEY:
+            case CAMEL_KAFKA_SASL_JAAS_CONFIG_KEY:
+                String username = saslBroker.get().sasl.username;
+                String password = saslBroker.get().sasl.password;
+                switch (saslBroker.get().sasl.saslMechanism) {
+                    case "PLAIN":
+                        return "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
+                    case "SCRAM-SHA-512":
+                        return "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + username + "\" password=\"" + password + "\";";
+                }
+            case KAFKA_SASL_MECHANISM_KEY:
+            case CAMEL_KAFKA_SASL_MECHANISM_KEY:
+                return saslBroker.get().sasl.saslMechanism;
+            case KAFKA_SECURITY_PROTOCOL_KEY:
+            case CAMEL_KAFKA_SECURITY_PROTOCOL_KEY:
+                return saslBroker.get().sasl.securityProtocol;
+            case KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
+            case CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
+                return createTempKafkaCertFile(saslBroker.get().cacert);
+            case KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
+            case CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
+                return KAFKA_SSL_TRUSTSTORE_TYPE_VALUE;
+            default:
+                // if it's a ssl key too, let's try using the Kafka SSL configuration
+                if (KAFKA_SSL_KEYS.contains(property) && sslBroker.isPresent()) {
+                    return handleKafkaSslKey(property, configSource);
+                }
+
+                throw new IllegalStateException(String.format("Config key: '%s' shouldn't be present for a Kafka SASL configuration, please check your config file", property));
+        }
+    }
+
+    private String handleKafkaSslKey(String property, ClowderConfigSource configSource) {
+        switch (property) {
+            case KAFKA_SECURITY_PROTOCOL_KEY:
+            case CAMEL_KAFKA_SECURITY_PROTOCOL_KEY:
+                return sslBroker.get().securityProtocol;
+            case KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
+            case CAMEL_KAFKA_SSL_TRUSTSTORE_LOCATION_KEY:
+                return createTempKafkaCertFile(sslBroker.get().cacert);
+            case KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
+            case CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
+                if (configSource.getValue(KAFKA_SSL_TRUSTSTORE_LOCATION_KEY) != null) {
+                    return KAFKA_SSL_TRUSTSTORE_TYPE_VALUE;
+                }
+            default:
+                throw new IllegalStateException(String.format("Config key: '%s' shouldn't be present for a Kafka SSL configuration, please check your config file", property));
+        }
+    }
+
+    private String createTempKafkaCertFile(String certData) {
+        return certData != null ? createTempCertFile("kafka-cacert", certData) : null;
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/KafkaSecurityClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/KafkaSecurityClowderPropertyHandler.java
@@ -121,11 +121,6 @@ public class KafkaSecurityClowderPropertyHandler extends ClowderPropertyHandler 
             case CAMEL_KAFKA_SSL_TRUSTSTORE_TYPE_KEY:
                 return KAFKA_SSL_TRUSTSTORE_TYPE_VALUE;
             default:
-                // if it's a ssl key too, let's try using the Kafka SSL configuration
-                if (KAFKA_SSL_KEYS.contains(property) && sslBroker.isPresent()) {
-                    return handleKafkaSslKey(property, configSource);
-                }
-
                 throw new IllegalStateException(String.format("Config key: '%s' shouldn't be present for a Kafka SASL configuration, please check your config file", property));
         }
     }

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/MicroprofileMessagingClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/MicroprofileMessagingClowderPropertyHandler.java
@@ -1,0 +1,34 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+import com.redhat.cloud.common.clowder.configsource.TopicConfig;
+
+public class MicroprofileMessagingClowderPropertyHandler extends ClowderPropertyHandler {
+
+    public MicroprofileMessagingClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public boolean handles(String property) {
+        return property.startsWith("mp.messaging") && property.endsWith(".topic");
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        if (clowderConfig.kafka == null) {
+            throw new IllegalStateException("Kafka base object not present, can't set Kafka values");
+        }
+        // We need to find the replaced topic by first finding
+        // the requested name and then getting the replaced name
+        String requested = configSource.getExistingValue(property);
+        for (TopicConfig topic : clowderConfig.kafka.topics) {
+            if (topic.requestedName.equals(requested)) {
+                return topic.name;
+            }
+        }
+
+        return requested;
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/OptionalEndpointsClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/OptionalEndpointsClowderPropertyHandler.java
@@ -1,0 +1,33 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class OptionalEndpointsClowderPropertyHandler extends EndpointsClowderPropertyHandler {
+
+    private static final String CLOWDER_OPTIONAL_ENDPOINTS = "clowder.optional-endpoints.";
+
+    public OptionalEndpointsClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        try {
+            if (clowderConfig.endpoints == null) {
+                configSource.getLogger().infof("No endpoints section found. Returning empty string for the \"%s\" configuration key", property);
+                return "";
+            }
+
+            return processEndpoints(property, configSource, clowderConfig.endpoints, "Endpoint");
+        } catch (final IllegalStateException e) {
+            configSource.getLogger().errorf("Failed to load config key '%s' from the Clowder configuration: %s", property, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    protected String getPropertyEndpointKey() {
+        return CLOWDER_OPTIONAL_ENDPOINTS;
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/OptionalPrivateEndpointsClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/OptionalPrivateEndpointsClowderPropertyHandler.java
@@ -1,0 +1,33 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class OptionalPrivateEndpointsClowderPropertyHandler extends EndpointsClowderPropertyHandler {
+
+    private static final String CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS = "clowder.optional-private-endpoints.";
+
+    public OptionalPrivateEndpointsClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        try {
+            if (clowderConfig.privateEndpoints == null) {
+                configSource.getLogger().infof("No private endpoints section found. Returning empty string for the \"%s\" configuration key", property);
+                return "";
+            }
+
+            return this.processEndpoints(property, configSource, clowderConfig.privateEndpoints, "Private endpoint");
+        } catch (IllegalStateException e) {
+            configSource.getLogger().errorf("Failed to load config key '%s' from the Clowder configuration: %s", property, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    protected String getPropertyEndpointKey() {
+        return CLOWDER_OPTIONAL_PRIVATE_ENDPOINTS;
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/PrivateEndpointsClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/PrivateEndpointsClowderPropertyHandler.java
@@ -1,0 +1,32 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class PrivateEndpointsClowderPropertyHandler extends EndpointsClowderPropertyHandler {
+
+    private static final String CLOWDER_PRIVATE_ENDPOINTS = "clowder.private-endpoints.";
+
+    public PrivateEndpointsClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        try {
+            if (clowderConfig.privateEndpoints == null) {
+                throw new IllegalStateException("No private endpoints section found");
+            }
+
+            return this.processEndpoints(property, configSource, clowderConfig.privateEndpoints, "Private endpoint");
+        } catch (IllegalStateException e) {
+            configSource.getLogger().errorf("Failed to load config key '%s' from the Clowder configuration: %s", property, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    protected String getPropertyEndpointKey() {
+        return CLOWDER_PRIVATE_ENDPOINTS;
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusDataSourceClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusDataSourceClowderPropertyHandler.java
@@ -1,0 +1,106 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+import com.redhat.cloud.common.clowder.configsource.DatabaseConfig;
+
+import static com.redhat.cloud.common.clowder.configsource.utils.CertUtils.createTempCertFile;
+
+public class QuarkusDataSourceClowderPropertyHandler extends ClowderPropertyHandler {
+
+    private static final String QUARKUS_DATASOURCE = "quarkus.datasource.";
+    private static final String QUARKUS_DATASOURCE_JDBC_URL = "quarkus.datasource.jdbc.url";
+
+    public QuarkusDataSourceClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public boolean handles(String property) {
+        return property.startsWith(QUARKUS_DATASOURCE);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        if (clowderConfig.database == null) {
+            throw new IllegalStateException("No database section found");
+        }
+
+        String item = property.substring(QUARKUS_DATASOURCE.length());
+        if (item.equals("username")) {
+            return clowderConfig.database.username;
+        }
+
+        String sslMode = clowderConfig.database.sslMode;
+        boolean useSsl = !sslMode.equals("disable");
+        boolean verifyFull = sslMode.equals("verify-full");
+        if (item.equals("password")) {
+            return clowderConfig.database.password;
+        }
+
+        if (item.equals("jdbc.url")) {
+            String hostPortDb = getHostPortDb(clowderConfig.database);
+            String tracing = "";
+            String jdbcUrl = configSource.getExistingValue(QUARKUS_DATASOURCE_JDBC_URL);
+            if (jdbcUrl != null) {
+                if (jdbcUrl.contains(":tracing:")) {
+                    // TODO Remove this block (tracing) later.
+                    configSource.getLogger().warn("The support of OpenTracing in this library is deprecated and will be removed soon. Please consider switching to OpenTelemetry.");
+                    tracing = "tracing:";
+                } else if (jdbcUrl.contains(":otel:")) {
+                    /*
+                     * The existing JDBC URL is the one coming from the application.properties file.
+                     * If that URL contains "otel" then it means that the app is able to connect to
+                     * the database through the OpenTelemetry JDBC layer.
+                     */
+                    tracing = "otel:";
+                }
+            }
+
+            jdbcUrl = String.format("jdbc:%s%s", tracing, hostPortDb);
+            if (useSsl) {
+                jdbcUrl = jdbcUrl + "?sslmode=" + sslMode;
+            }
+            if (verifyFull) {
+                jdbcUrl = jdbcUrl + "&sslrootcert=" + createTempRdsCertFile(clowderConfig.database.rdsCa);
+            }
+            return jdbcUrl;
+        }
+        if (item.startsWith("reactive.")) {
+            if (item.equals("reactive.url")) {
+                return getHostPortDb(clowderConfig.database);
+            }
+            if (item.equals("reactive.postgresql.ssl-mode")) {
+                return sslMode;
+            }
+            if (verifyFull) {
+                if (item.equals("reactive.hostname-verification-algorithm")) {
+                    return "HTTPS";
+                }
+                if (item.equals("reactive.trust-certificate-pem")) {
+                    return "true";
+                }
+                if (item.equals("reactive.trust-certificate-pem.certs")) {
+                    return createTempRdsCertFile(clowderConfig.database.rdsCa);
+                }
+            }
+        }
+
+        return configSource.getExistingValue(property);
+    }
+
+    private String getHostPortDb(DatabaseConfig database) {
+        return String.format("postgresql://%s:%d/%s",
+                database.hostname,
+                database.port,
+                database.name);
+    }
+
+    private String createTempRdsCertFile(String certData) {
+        if (certData != null) {
+            return createTempCertFile("rds-ca-root", certData);
+        } else {
+            throw new IllegalStateException("'database.sslMode' is set to 'verify-full' in the Clowder config but the 'database.rdsCa' field is missing");
+        }
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusLogCloudWatchClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusLogCloudWatchClowderPropertyHandler.java
@@ -1,0 +1,58 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class QuarkusLogCloudWatchClowderPropertyHandler extends ClowderPropertyHandler {
+
+    private static final String QUARKUS_LOG_CLOUDWATCH = "quarkus.log.cloudwatch";
+
+    public QuarkusLogCloudWatchClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    @Override
+    public boolean handles(String property) {
+        return property.startsWith(QUARKUS_LOG_CLOUDWATCH);
+    }
+
+    @Override
+    public String handle(String property, ClowderConfigSource configSource) {
+        if (clowderConfig.logging == null) {
+            throw new IllegalStateException("No logging section found");
+        }
+        if (clowderConfig.logging.cloudwatch == null) {
+            throw new IllegalStateException("No cloudwatch section found in logging object");
+        }
+
+        // Check for not null type and not "null" provider to enable and read
+        // cloudwatch properties from Clowder config.
+        // Note that the "null" type is a Clowder logging provider that disables
+        // central logging.
+        // Empty string type has to be treated as cloudwatch, as one of the Clowder
+        // logging providers (appinterface) did not set it correctly.
+        if (clowderConfig.logging.type != null && !clowderConfig.logging.type.equals("null")) {
+            int prefixLen = QUARKUS_LOG_CLOUDWATCH.length();
+            String sub = property.substring(prefixLen + 1);
+            switch (sub) {
+                case "access-key-id":
+                    return clowderConfig.logging.cloudwatch.accessKeyId;
+                case "access-key-secret":
+                    return clowderConfig.logging.cloudwatch.secretAccessKey;
+                case "region":
+                    return clowderConfig.logging.cloudwatch.region;
+                case "log-group":
+                    return clowderConfig.logging.cloudwatch.logGroup;
+                default:
+                    // fall through to fetching the value from application.properties
+            }
+        } else {
+            // treat null logging type as disabled CloudWatch logging
+            if (property.equals(QUARKUS_LOG_CLOUDWATCH + ".enabled")) {
+                return "false";
+            }
+        }
+
+        return configSource.getExistingValue(property);
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusUnleashClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusUnleashClowderPropertyHandler.java
@@ -1,0 +1,37 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class QuarkusUnleashClowderPropertyHandler extends ClowderPropertyHandler {
+    private static final String QUARKUS_UNLEASH = "quarkus.unleash.";
+
+    public QuarkusUnleashClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    public boolean handles(String property) {
+        return property.startsWith(QUARKUS_UNLEASH);
+    }
+
+    public String handle(String property, ClowderConfigSource configSource) {
+        if (clowderConfig.featureFlags == null) {
+            configSource.getLogger().warn("Unleash configuration requested by Quarkus but not found the Clowder configuration");
+        } else {
+            String item = property.substring(QUARKUS_UNLEASH.length());
+            if (item.equals("token")) {
+                return clowderConfig.featureFlags.clientAccessToken;
+            }
+            if (item.equals("url")) {
+                String url = String.format("%s://%s", clowderConfig.featureFlags.scheme, clowderConfig.featureFlags.hostname);
+                if (clowderConfig.featureFlags.port != null) {
+                    url += ":" + clowderConfig.featureFlags.port;
+                }
+                url += "/api";
+                return url;
+            }
+        }
+
+        return configSource.getExistingValue(property);
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/WebPortClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/WebPortClowderPropertyHandler.java
@@ -1,0 +1,20 @@
+package com.redhat.cloud.common.clowder.configsource.handlers;
+
+import com.redhat.cloud.common.clowder.configsource.ClowderConfig;
+import com.redhat.cloud.common.clowder.configsource.ClowderConfigSource;
+
+public class WebPortClowderPropertyHandler extends ClowderPropertyHandler {
+    private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
+
+    public WebPortClowderPropertyHandler(ClowderConfig clowderConfig) {
+        super(clowderConfig);
+    }
+
+    public boolean handles(String property) {
+        return property.equals(QUARKUS_HTTP_PORT);
+    }
+
+    public String handle(String property, ClowderConfigSource configSource) {
+        return String.valueOf(clowderConfig.webPort);
+    }
+}

--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/utils/CertUtils.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/utils/CertUtils.java
@@ -1,0 +1,42 @@
+package com.redhat.cloud.common.clowder.configsource.utils;
+
+import org.jboss.logging.Logger;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public final class CertUtils {
+
+    public static final Logger LOG = Logger.getLogger(CertUtils.class.getName());
+
+    private CertUtils() {
+
+    }
+
+    public static String createTempCertFile(String fileName, String certData) {
+        byte[] cert = certData.getBytes(StandardCharsets.UTF_8);
+
+        try {
+            File certFile = createTempFile(fileName, ".crt");
+            return Files.write(Path.of(certFile.getAbsolutePath()), cert).toString();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Certificate file creation failed", e);
+        }
+    }
+
+    public static File createTempFile(String fileName, String suffix) throws IOException {
+        File file = File.createTempFile(fileName, suffix);
+
+        try {
+            file.deleteOnExit();
+        } catch (SecurityException e) {
+            LOG.warnf(e, "Delete on exit of the '%s' cert file denied by the security manager", fileName);
+        }
+
+        return file;
+    }
+}

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -883,7 +883,7 @@ public class ConfigSourceTest {
         try {
             return new String(is.readAllBytes(), UTF_8);
         } catch (IOException ex) {
-            Assertions.fail("File '" + filename + "' not found!");
+            Assertions.fail("Error reading '" + filename + "'", ex);
             return null;
         }
     }

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -881,7 +881,7 @@ public class ConfigSourceTest {
         InputStream is = ConfigSourceTest.class.getResourceAsStream(filename);
 
         try {
-            return new String(is.readAllBytes());
+            return new String(is.readAllBytes(), UTF_8);
         } catch (IOException ex) {
             Assertions.fail("File '" + filename + "' not found!");
             return null;


### PR DESCRIPTION
Before these changes, the Clowder config source was keeping in memory all the properties from all the sources in the **existingValues** property. Apart from this, the clowder config source was used even when the clowder file is not set. 

This pull request addresses both issues by:
- Refactoring the solution to use the ClowderPropertyHandler interface. 

This interface implements a decorator pattern, so the config source will only keep the properties in memory if and only if there is any handler that handles it. 

- Also, if the clowder file does not exist, it will print a warning, and will not register the clowder config source.  

Relates to [SWATCH-2037](https://issues.redhat.com/browse/SWATCH-2037)