### PR TITLE
fix: null pointer exception when attempting to read a system property

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/ClowderConfigSource.java
@@ -257,7 +257,7 @@ public class ClowderConfigSource implements ConfigSource {
     }
 
     private String resolveValue(String property) {
-        if (!hasComputedProperties(property)) {
+        if (property == null || property.isEmpty() || !hasComputedProperties(property)) {
             return property;
         }
 
@@ -282,7 +282,9 @@ public class ClowderConfigSource implements ConfigSource {
                 value = getPropertyFromSystem(systemProperty, value);
             }
 
-            property = property.replace(PROPERTY_START + rawSystemProperty + PROPERTY_END, value);
+            if (value != null) {
+                property = property.replace(PROPERTY_START + rawSystemProperty + PROPERTY_END, value);
+            }
         }
 
         return property;

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -115,6 +115,12 @@ public class ConfigSourceTest {
     }
 
     @Test
+    void testKafkaOutgoingWithSystemPropertyThatDoesNotExist() {
+        String topic = ccs.getValue("mp.messaging.outgoing.system.not.exist.topic");
+        assertEquals("${NO_EXIST}", topic);
+    }
+
+    @Test
     void testKafkaOutgoingWithNestedSystemProperty() {
         String topic = ccs.getValue("mp.messaging.outgoing.nested-properties.topic");
         assertEquals("platform-nested-properties", topic);

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -25,6 +25,9 @@ nested.property.topic=nested-topic
 mp.messaging.outgoing.nested-properties.connector=smallrye-kafka
 mp.messaging.outgoing.nested-properties.topic=${NO_EXIST:${nested.property.topic}}
 
+# System queue to test system properties that do not exist
+mp.messaging.outgoing.system.not.exist.topic=${NO_EXIST}
+
 # System queue to test properties defined in other keys
 custom.property.topic=custom-topic
 mp.messaging.incoming.computed.connector=smallrye-kafka


### PR DESCRIPTION
Caused by the changes in https://github.com/RedHatInsights/clowder-quarkus-config-source/pull/218. 
It was causing null pointer exceptions in some of our services due to this. 