### PR TITLE
fix: remove collision with quarkus-redis-client properties

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
@@ -24,8 +24,8 @@ public class QuarkusRedisClowderPropertyHandler extends ClowderPropertyHandler {
         String sub = property.substring(QUARKUS_REDIS.length());
 
         return switch (sub) {
-            case "hosts" -> "redis://" + clowderConfig.inMemoryDb.hostname + ":" + clowderConfig.inMemoryDb.port;
-            case "password" ->
+            case "host-uri" -> "redis://" + clowderConfig.inMemoryDb.hostname + ":" + clowderConfig.inMemoryDb.port;
+            case "pass" ->
                     clowderConfig.inMemoryDb.password;
             default ->
                     configSource.getExistingValue(property); // fallback to fetching the value from application.properties

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -171,17 +171,17 @@ public class ConfigSourceTest {
 
     @Test
     void testInMemoryDb() {
-        String hosts = ccs.getValue("quarkus.redis.hosts");
+        String hosts = ccs.getValue("quarkus.redis.host-uri");
         assertEquals("redis://some.redis.host:6379", hosts);
     }
 
     @Test
     void testInMemoryDbWithCredentials() {
         ClowderConfigSource ccs2 = configSourceWithFile("/cdappconfig2.json", exposeKafkaSslConfigKeys);
-        String hosts = ccs2.getValue("quarkus.redis.hosts");
+        String hosts = ccs2.getValue("quarkus.redis.host-uri");
         assertEquals("redis://some.redis.db:6379", hosts);
 
-        String password = ccs2.getValue("quarkus.redis.password");
+        String password = ccs2.getValue("quarkus.redis.pass");
         assertEquals("secret", password);
     }
 


### PR DESCRIPTION
When I originally added support for handling the `inMemoryDb` variables in #291, I wasn't aware that the properties names provided would collide with those used in `io.quarkus:quarkus-redis-client` ([reference](https://quarkus.io/guides/redis-reference#quarkus-redis-client_quarkus-redis-hosts)). This PR changes the property names to avoid those collisions:

- `quarkus.redis.hosts` -> `quarkus.redis.host-uri`
- `quarkus.redis.password` -> `quarkus.redis.pass`

JIRA ticket: https://issues.redhat.com/browse/RHCLOUD-36096