### PR TITLE
fix: use rediss:// for quarkus.redis.hosts if password provided

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
@@ -24,9 +24,12 @@ public class QuarkusRedisClowderPropertyHandler extends ClowderPropertyHandler {
         String sub = property.substring(QUARKUS_REDIS.length());
 
         return switch (sub) {
-            case "hosts" -> "redis://" + clowderConfig.inMemoryDb.hostname + ":" + clowderConfig.inMemoryDb.port;
-            case "password" ->
-                    clowderConfig.inMemoryDb.password;
+            case "hosts" -> {
+                // If password is provided by cdappconfig.json, in-transit encryption is enabled (see clowder#1126).
+                String scheme = clowderConfig.inMemoryDb.password != null && !clowderConfig.inMemoryDb.password.isBlank() ? "rediss://" : "redis://";
+                yield scheme + clowderConfig.inMemoryDb.hostname + ":" + clowderConfig.inMemoryDb.port;
+            }
+            case "password" -> clowderConfig.inMemoryDb.password;
             default ->
                     configSource.getExistingValue(property); // fallback to fetching the value from application.properties
         };

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -179,7 +179,7 @@ public class ConfigSourceTest {
     void testInMemoryDbWithCredentials() {
         ClowderConfigSource ccs2 = configSourceWithFile("/cdappconfig2.json", exposeKafkaSslConfigKeys);
         String hosts = ccs2.getValue("quarkus.redis.hosts");
-        assertEquals("redis://some.redis.db:6379", hosts);
+        assertEquals("rediss://some.redis.db:6379", hosts);
 
         String password = ccs2.getValue("quarkus.redis.password");
         assertEquals("secret", password);


### PR DESCRIPTION
https://issues.redhat.com/browse/RHCLOUD-36096

This is based on RedHatInsights/clowder#1126, which only sets passwords for ElastiCache (not local Redis instances), following AWS requirements that in-transit encryption be enabled to use an AUTH/RBAC password.