### PR TITLE
[RHCLOUD-47668] Change missing inMemoryDb in `quarkus.redis` to non-fatal warning

### DIFF
--- a/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
+++ b/src/main/java/com/redhat/cloud/common/clowder/configsource/handlers/QuarkusRedisClowderPropertyHandler.java
@@ -18,7 +18,8 @@ public class QuarkusRedisClowderPropertyHandler extends ClowderPropertyHandler {
     @Override
     public String handle(String property, ClowderConfigSource configSource) {
         if (clowderConfig.inMemoryDb == null) {
-            throw new IllegalStateException("No inMemoryDb section found");
+            configSource.getLogger().warnf("No inMemoryDb section found in Clowder configuration, fallback to existing value for \"%s\" configuration key.", property);
+            return configSource.getExistingValue(property);
         }
 
         String sub = property.substring(QUARKUS_REDIS.length());

--- a/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
+++ b/src/test/java/com/redhat/cloud/common/clowder/configsource/ConfigSourceTest.java
@@ -286,7 +286,10 @@ public class ConfigSourceTest {
     @Test
     void testNoInMemoryDbSection() {
         ClowderConfigSource source = configSourceWithFile("/cdappconfig3.json", exposeKafkaSslConfigKeys);
-        assertThrows(IllegalStateException.class, () -> source.getValue("quarkus.redis.hosts"));
+        String hosts = source.getValue("quarkus.redis.hosts");
+        assertNull(hosts);
+        String password = source.getValue("quarkus.redis.password");
+        assertNull(password);
     }
 
     @Test


### PR DESCRIPTION
## Jira ticket

https://redhat.atlassian.net/browse/RHCLOUD-47668

## Description

For `quarkus.redis` properties, if `inMemoryDb` is not present, return a warning and use the existing value, instead of throwing an `IllegalStateException`. This allows for configuration to continue if an Elasticache instance is not provisioned. Implementation based on QuarkusUnleashClowderPropertyHandler

Also updated the corresponding test case.

## Compatibilty

Breaking change, in that a missing `inMemoryDb` section in cdappconfig.json will no longer throw an exception.

## AI review

Reviewed by [claude-engineering-toolkit](https://github.com/gwenneg/claude-engineering-toolkit), and mentioned findings in PR description.