### PR TITLE
Update Jandex plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,9 +93,9 @@
     <plugins>
       <!-- jandex is needed for @RegisterForReflection annotation to work properly (native mode support) -->
       <plugin>
-        <groupId>org.jboss.jandex</groupId>
+        <groupId>io.smallrye</groupId>
         <artifactId>jandex-maven-plugin</artifactId>
-        <version>1.2.3</version>
+        <version>3.5.3</version>
         <executions>
           <execution>
             <id>make-index</id>


### PR DESCRIPTION
The org.jboss.jandex:jandex-maven-plugin has not been updated since 28
June, 2022.  This results in a Jandex 2.0 format index, but Quarkus 3
requires a Jandex 3.0 format index.  The resulting mismatch means that
Quarkus has to reindex during a Maven build which slows the build down
slightly.

This commit changes to use the io.smallrye:jandex-maven-plugin which is
under more active development.
