### PR TITLE
[RHCLOUD-48971] Update Github auto-release action for clowder-quarkus-config-source project

### DIFF
--- a/.github/scripts/prepare-release.sh
+++ b/.github/scripts/prepare-release.sh
@@ -10,12 +10,17 @@
 # GitHub's REST/Git-Data API by a plain GITHUB_TOKEN.
 set -euo pipefail
 
+RELEASE_SUBJECT_PREFIX="chore(main): release"
+
 LAST_SUBJECT=$(git log -1 --pretty=%s)
-if [[ "${LAST_SUBJECT}" =~ ^chore\(main\):\ release\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
-  echo "HEAD is already a release commit for ${BASH_REMATCH[1]}, nothing to prepare."
-  echo "release_created=true" >>"${GITHUB_OUTPUT}"
-  echo "version=${BASH_REMATCH[1]}" >>"${GITHUB_OUTPUT}"
-  exit 0
+if [[ "${LAST_SUBJECT}" == "${RELEASE_SUBJECT_PREFIX} "* ]]; then
+  VERSION_PART="${LAST_SUBJECT#"${RELEASE_SUBJECT_PREFIX} "}"
+  if [[ "${VERSION_PART}" =~ ^([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+    echo "HEAD is already a release commit for ${BASH_REMATCH[1]}, nothing to prepare."
+    echo "release_created=true" >>"${GITHUB_OUTPUT}"
+    echo "version=${BASH_REMATCH[1]}" >>"${GITHUB_OUTPUT}"
+    exit 0
+  fi
 fi
 
 LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)
@@ -112,10 +117,19 @@ if [ -z "${KEY_FINGERPRINT}" ]; then
   exit 1
 fi
 
+cleanup() {
+  gpg --batch --yes --delete-secret-and-public-key "${KEY_FINGERPRINT}" >/dev/null 2>&1 || true
+  gpgconf --kill gpg-agent || true
+  rm -rf ~/.gnupg
+  git config --unset user.signingkey || true
+  git config --unset commit.gpgsign || true
+}
+trap cleanup EXIT
+
 echo "allow-preset-passphrase" >>~/.gnupg/gpg-agent.conf
 gpg-connect-agent reloadagent /bye
 KEYGRIP=$(gpg --list-secret-keys --with-keygrip --with-colons 2>/dev/null | awk -F: '/^grp/{print $10; exit}')
-if ! /usr/lib/gnupg/gpg-preset-passphrase --preset "${KEYGRIP}" <<<"${RELEASE_BOT_GPG_PASSPHRASE}"; then
+if ! printenv RELEASE_BOT_GPG_PASSPHRASE | /usr/lib/gnupg/gpg-preset-passphrase --preset "${KEYGRIP}"; then
   echo "Error: failed to preset GPG passphrase." >&2
   exit 1
 fi
@@ -127,23 +141,17 @@ git config user.email "${RELEASE_BOT_EMAIL}"
 
 git checkout -b "${BRANCH}"
 git add pom.xml CHANGELOG.md
-git commit -S -m "chore(main): release ${NEW_VERSION}"
+git commit -S -m "${RELEASE_SUBJECT_PREFIX} ${NEW_VERSION}"
 git push origin "${BRANCH}"
 
 gh label create "autorelease: pending" --color BFD4F2 --description "Automated release PR, ready to auto-merge" --force
 
 PR_URL=$(gh pr create \
-  --title "chore(main): release ${NEW_VERSION}" \
+  --title "${RELEASE_SUBJECT_PREFIX} ${NEW_VERSION}" \
   --body "Automated release PR for v${NEW_VERSION}. Auto-merges once opened." \
   --base main \
   --head "${BRANCH}" \
   --label "autorelease: pending")
-
-gpg --batch --yes --delete-secret-and-public-key "${KEY_FINGERPRINT}" || true
-gpgconf --kill gpg-agent || true
-rm -rf ~/.gnupg
-git config --unset user.signingkey || true
-git config --unset commit.gpgsign || true
 
 echo "release_created=false" >>"${GITHUB_OUTPUT}"
 echo "pr_url=${PR_URL}" >>"${GITHUB_OUTPUT}"

--- a/.github/scripts/prepare-release.sh
+++ b/.github/scripts/prepare-release.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Computes the next version from conventional commits since the last tag and
+# opens a release PR, or recognizes that HEAD already *is* a release commit.
+#
+# Commits are GPG-signed using a bot identity whose public key is registered
+# on GitHub, via RELEASE_BOT_GPG_PRIVATE_KEY/RELEASE_BOT_GPG_PASSPHRASE and
+# RELEASE_BOT_NAME/RELEASE_BOT_EMAIL (which must match a verified name/email
+# on that account). Because the signature is real, it satisfies the org's
+# "required_signatures" ruleset on any branch, unlike commits created through
+# GitHub's REST/Git-Data API by a plain GITHUB_TOKEN.
+set -euo pipefail
+
+LAST_SUBJECT=$(git log -1 --pretty=%s)
+if [[ "${LAST_SUBJECT}" =~ ^chore\(main\):\ release\ (.+)$ ]]; then
+  echo "HEAD is already a release commit for ${BASH_REMATCH[1]}, nothing to prepare."
+  echo "release_created=true" >>"${GITHUB_OUTPUT}"
+  echo "version=${BASH_REMATCH[1]}" >>"${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+LATEST_TAG=$(git tag -l 'v*' --sort=-v:refname | head -n1)
+if [ -z "${LATEST_TAG}" ]; then
+  echo "No previous v* tag found, cannot compute a base version." >&2
+  echo "release_created=false" >>"${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+RANGE="${LATEST_TAG}..HEAD"
+SUBJECTS=$(git log "${RANGE}" --pretty=format:'%s')
+BODIES=$(git log "${RANGE}" --pretty=format:'%b')
+
+BUMP=none
+if echo "${SUBJECTS}" | grep -qE '^[a-zA-Z]+(\([^)]*\))?!:' || echo "${BODIES}" | grep -q 'BREAKING CHANGE:'; then
+  BUMP=major
+elif echo "${SUBJECTS}" | grep -qE '^feat(\([^)]*\))?:'; then
+  BUMP=minor
+elif echo "${SUBJECTS}" | grep -qE '^fix(\([^)]*\))?:'; then
+  BUMP=patch
+fi
+
+if [ "${BUMP}" = none ]; then
+  echo "No releasable (feat/fix/breaking) commits since ${LATEST_TAG}."
+  echo "release_created=false" >>"${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+VERSION="${LATEST_TAG#v}"
+IFS='.' read -r MAJOR MINOR PATCH <<<"${VERSION%%-*}"
+case "${BUMP}" in
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  patch) PATCH=$((PATCH + 1)) ;;
+esac
+NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+echo "Bumping ${LATEST_TAG} -> v${NEW_VERSION} (${BUMP})"
+
+./mvnw -q -B versions:set-property -Dproperty=revision -DnewVersion="${NEW_VERSION}" -DgenerateBackupPoms=false
+
+FEATURES=$(git log "${RANGE}" -E --grep='^feat(\([^)]*\))?:' --pretty=format:"* %s ([%h](https://github.com/${GITHUB_REPOSITORY}/commit/%H))")
+FIXES=$(git log "${RANGE}" -E --grep='^fix(\([^)]*\))?:' --pretty=format:"* %s ([%h](https://github.com/${GITHUB_REPOSITORY}/commit/%H))")
+
+{
+  echo "# Changelog"
+  echo
+  echo "## [${NEW_VERSION}](https://github.com/${GITHUB_REPOSITORY}/compare/${LATEST_TAG}...v${NEW_VERSION})"
+  if [ -n "${FEATURES}" ]; then
+    echo
+    echo "### Features"
+    echo
+    echo "${FEATURES}"
+  fi
+  if [ -n "${FIXES}" ]; then
+    echo
+    echo "### Bug Fixes"
+    echo
+    echo "${FIXES}"
+  fi
+  echo
+  tail -n +2 CHANGELOG.md
+} >CHANGELOG.md.new
+mv CHANGELOG.md.new CHANGELOG.md
+
+for var in RELEASE_BOT_GPG_PRIVATE_KEY RELEASE_BOT_GPG_PASSPHRASE RELEASE_BOT_NAME RELEASE_BOT_EMAIL; do
+  if [ -z "${!var:-}" ]; then
+    echo "Error: ${var} secret is not configured." >&2
+    exit 1
+  fi
+done
+
+if ! printenv RELEASE_BOT_GPG_PRIVATE_KEY | gpg --batch --import; then
+  echo "Error: failed to import RELEASE_BOT_GPG_PRIVATE_KEY. Check it's a valid ASCII-armored key." >&2
+  exit 1
+fi
+KEY_FINGERPRINT=$(gpg --list-secret-keys --with-colons --fingerprint 2>/dev/null | awk -F: '/^fpr/{print $10; exit}')
+if [ -z "${KEY_FINGERPRINT}" ]; then
+  echo "Error: no GPG secret key found after import." >&2
+  exit 1
+fi
+
+echo "allow-preset-passphrase" >>~/.gnupg/gpg-agent.conf
+gpg-connect-agent reloadagent /bye
+KEYGRIP=$(gpg --list-secret-keys --with-keygrip --with-colons 2>/dev/null | awk -F: '/^grp/{print $10; exit}')
+if ! /usr/lib/gnupg/gpg-preset-passphrase --preset "${KEYGRIP}" <<<"${RELEASE_BOT_GPG_PASSPHRASE}"; then
+  echo "Error: failed to preset GPG passphrase." >&2
+  exit 1
+fi
+
+git config user.signingkey "${KEY_FINGERPRINT}"
+git config commit.gpgsign true
+git config user.name "${RELEASE_BOT_NAME}"
+git config user.email "${RELEASE_BOT_EMAIL}"
+
+BRANCH="release/v${NEW_VERSION}"
+git checkout -b "${BRANCH}"
+git add pom.xml CHANGELOG.md
+git commit -S -m "chore(main): release ${NEW_VERSION}"
+git push origin "${BRANCH}"
+
+gh label create "autorelease: pending" --color BFD4F2 --description "Automated release PR, ready to auto-merge" --force
+
+PR_URL=$(gh pr create \
+  --title "chore(main): release ${NEW_VERSION}" \
+  --body "Automated release PR for v${NEW_VERSION}. Auto-merges once opened." \
+  --base main \
+  --head "${BRANCH}" \
+  --label "autorelease: pending")
+
+gpg --batch --yes --delete-secret-and-public-key "${KEY_FINGERPRINT}" || true
+gpgconf --kill gpg-agent || true
+rm -rf ~/.gnupg
+git config --unset user.signingkey || true
+git config --unset commit.gpgsign || true
+
+echo "release_created=false" >>"${GITHUB_OUTPUT}"
+echo "pr_url=${PR_URL}" >>"${GITHUB_OUTPUT}"

--- a/.github/scripts/prepare-release.sh
+++ b/.github/scripts/prepare-release.sh
@@ -11,7 +11,7 @@
 set -euo pipefail
 
 LAST_SUBJECT=$(git log -1 --pretty=%s)
-if [[ "${LAST_SUBJECT}" =~ ^chore\(main\):\ release\ (.+)$ ]]; then
+if [[ "${LAST_SUBJECT}" =~ ^chore\(main\):\ release\ ([0-9]+\.[0-9]+\.[0-9]+) ]]; then
   echo "HEAD is already a release commit for ${BASH_REMATCH[1]}, nothing to prepare."
   echo "release_created=true" >>"${GITHUB_OUTPUT}"
   echo "version=${BASH_REMATCH[1]}" >>"${GITHUB_OUTPUT}"
@@ -53,6 +53,21 @@ case "${BUMP}" in
 esac
 NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
 echo "Bumping ${LATEST_TAG} -> v${NEW_VERSION} (${BUMP})"
+
+BRANCH="release/v${NEW_VERSION}"
+
+EXISTING_PR_URL=$(gh pr list --head "${BRANCH}" --base main --state open --json url --jq '.[0].url // empty')
+if [ -n "${EXISTING_PR_URL}" ]; then
+  echo "Release PR for ${BRANCH} already exists, reusing ${EXISTING_PR_URL}."
+  echo "release_created=false" >>"${GITHUB_OUTPUT}"
+  echo "pr_url=${EXISTING_PR_URL}" >>"${GITHUB_OUTPUT}"
+  exit 0
+fi
+
+if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+  echo "Stale branch ${BRANCH} with no open PR found, deleting before recreating."
+  git push origin --delete "${BRANCH}"
+fi
 
 ./mvnw -q -B versions:set-property -Dproperty=revision -DnewVersion="${NEW_VERSION}" -DgenerateBackupPoms=false
 
@@ -110,7 +125,6 @@ git config commit.gpgsign true
 git config user.name "${RELEASE_BOT_NAME}"
 git config user.email "${RELEASE_BOT_EMAIL}"
 
-BRANCH="release/v${NEW_VERSION}"
 git checkout -b "${BRANCH}"
 git add pom.xml CHANGELOG.md
 git commit -S -m "chore(main): release ${NEW_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,35 +4,46 @@ on:
       - main
 name: release
 jobs:
-  release:
+  prepare-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      pr: ${{ steps.release.outputs.pr }}
+      release_created: ${{ steps.prepare.outputs.release_created }}
+      version: ${{ steps.prepare.outputs.version }}
+      pr_url: ${{ steps.prepare.outputs.pr_url }}
     steps:
-      - id: release
-        uses: googleapis/release-please-action@v5
+      - uses: actions/checkout@v6
         with:
-          release-type: maven
-          package-name: com.redhat.cloud.common.clowder-quarkus-config-source
-  auto-merge-snapshot:
-    needs: [ release ]
+          fetch-depth: 0
+      - id: prepare
+        name: Compute next version and open/recognize the release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BOT_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_GPG_PRIVATE_KEY }}
+          RELEASE_BOT_GPG_PASSPHRASE: ${{ secrets.RELEASE_BOT_GPG_PASSPHRASE }}
+          RELEASE_BOT_NAME: ${{ secrets.RELEASE_BOT_NAME }}
+          RELEASE_BOT_EMAIL: ${{ secrets.RELEASE_BOT_EMAIL }}
+        run: bash .github/scripts/prepare-release.sh
+  auto-merge-release:
+    needs: [ prepare-release ]
     runs-on: ubuntu-latest
-    if: "${{ needs.release.outputs.pr && contains(fromJSON(needs.release.outputs.pr).labels, 'autorelease: snapshot') }}"
+    if: "${{ needs.prepare-release.outputs.pr_url != '' }}"
     steps:
       - id: auto-merge
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          MERGE_LABELS: "autorelease: snapshot"
-          MERGE_METHOD: rebase
+          MERGE_LABELS: "autorelease: pending"
+          MERGE_METHOD: squash
           MERGE_RETRIES: 10
           MERGE_RETRY_SLEEP: 10000
-          PULL_REQUEST: ${{ fromJSON(needs.release.outputs.pr).number }}
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
   publish:
-    needs: [ release ]
+    needs: [ prepare-release ]
     runs-on: ubuntu-latest
-    if: ${{ needs.release.outputs.release_created }}
+    if: ${{ needs.prepare-release.outputs.release_created == 'true' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -53,9 +64,12 @@ jobs:
           echo "Key ID from secret: ${{ secrets.GPG_KEY_ID }}"
           echo "Testing key access:"
           gpg --list-secret-keys "${{ secrets.GPG_KEY_ID }}" || echo "Key not found with ID: ${{ secrets.GPG_KEY_ID }}"
-
       - name: Publish package
-        run: mvn deploy -Prelease -Dgpg.keyname="${{ secrets.GPG_KEY_ID }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+        run: mvn deploy -Prelease -Drevision="${{ needs.prepare-release.outputs.version }}" -Dgpg.keyname="${{ secrets.GPG_KEY_ID }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create "v${{ needs.prepare-release.outputs.version }}" --repo "${{ github.repository }}" --title "v${{ needs.prepare-release.outputs.version }}" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
 name: release
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
@@ -37,6 +40,7 @@ jobs:
         env:
           MERGE_LABELS: "autorelease: pending"
           MERGE_METHOD: squash
+          MERGE_COMMIT_MESSAGE: pull-request-title
           MERGE_RETRIES: 10
           MERGE_RETRY_SLEEP: 10000
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -65,11 +69,13 @@ jobs:
           echo "Testing key access:"
           gpg --list-secret-keys "${{ secrets.GPG_KEY_ID }}" || echo "Key not found with ID: ${{ secrets.GPG_KEY_ID }}"
       - name: Publish package
-        run: mvn deploy -Prelease -Drevision="${{ needs.prepare-release.outputs.version }}" -Dgpg.keyname="${{ secrets.GPG_KEY_ID }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
         env:
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        run: mvn deploy -Prelease -Drevision="${RELEASE_VERSION}" -Dgpg.keyname="${{ secrets.GPG_KEY_ID }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create "v${{ needs.prepare-release.outputs.version }}" --repo "${{ github.repository }}" --title "v${{ needs.prepare-release.outputs.version }}" --generate-notes
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: gh release create "v${RELEASE_VERSION}" --repo "${{ github.repository }}" --title "v${RELEASE_VERSION}" --target "${{ github.sha }}" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ on:
     branches:
       - main
 name: release
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-prepare-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: write
       pull-requests: write
@@ -52,6 +52,16 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
+        run: |
+          if gh release view "v${RELEASE_VERSION}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "Release v${RELEASE_VERSION} already exists, skipping creation."
+          else
+            gh release create "v${RELEASE_VERSION}" --repo "${{ github.repository }}" --title "v${RELEASE_VERSION}" --target "${{ github.sha }}" --generate-notes
+          fi
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v5
         with:
@@ -74,8 +84,3 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: mvn deploy -Prelease -Drevision="${RELEASE_VERSION}" -Dgpg.keyname="${{ secrets.GPG_KEY_ID }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
-        run: gh release create "v${RELEASE_VERSION}" --repo "${{ github.repository }}" --title "v${RELEASE_VERSION}" --target "${{ github.sha }}" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,16 +71,21 @@ jobs:
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
       - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
         run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+          printenv GPG_PRIVATE_KEY | gpg --batch --import
           echo "Available GPG keys:"
           gpg --list-secret-keys --keyid-format=long
-          echo "Key ID from secret: ${{ secrets.GPG_KEY_ID }}"
+          echo "Key ID from secret: ${GPG_KEY_ID}"
           echo "Testing key access:"
-          gpg --list-secret-keys "${{ secrets.GPG_KEY_ID }}" || echo "Key not found with ID: ${{ secrets.GPG_KEY_ID }}"
+          gpg --list-secret-keys "${GPG_KEY_ID}" || echo "Key not found with ID: ${GPG_KEY_ID}"
       - name: Publish package
         env:
           RELEASE_VERSION: ${{ needs.prepare-release.outputs.version }}
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-        run: mvn deploy -Prelease -Drevision="${RELEASE_VERSION}" -Dgpg.keyname="${{ secrets.GPG_KEY_ID }}" -Dgpg.passphrase="${{ secrets.GPG_PASSPHRASE }}"
+          GPG_KEYNAME: ${{ secrets.GPG_KEY_ID }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: mvn deploy -Prelease -Drevision="${RELEASE_VERSION}"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ hs_err_pid*
 *.iml
 
 target/
+
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.redhat.cloud.common</groupId>
   <artifactId>clowder-quarkus-config-source</artifactId>
-  <version>2.10.1-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <name>Clowder Quarkus Config Source</name>
@@ -12,6 +12,7 @@
   <url>https://github.com/RedHatInsights/clowder-quarkus-config-source</url>
 
   <properties>
+    <revision>2.10.1-SNAPSHOT</revision>
     <compiler-plugin.version>3.15.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <java.release>17</java.release>
@@ -143,6 +144,30 @@
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
           </systemProperties>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.7.0</version>
+        <configuration>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
release-please-action was failing on every push to main because an org-wide ruleset now requires signed commits on all branches, and release-please creates its scratch branch through the GitHub API without a real signature. This replaces it with a custom prepare-release.sh script that computes the next version from conventional commits since the last v* tag, bumps pom.xml's new ${revision} property (via
  flatten-maven-plugin), and opens a release PR using a real GPG-signed commit from a bot identity — which satisfies the ruleset.

  The workflow now auto-merges that PR (squash only, since rebase would invalidate the signature) and the publish job creates the GitHub release afterward, since release-please no longer does.

  Requires new repo secrets (RELEASE_BOT_GPG_PRIVATE_KEY, RELEASE_BOT_GPG_PASSPHRASE, RELEASE_BOT_NAME, RELEASE_BOT_EMAIL) and an initial v* baseline tag before merging, since this repo has no existing tags.
